### PR TITLE
Add many mapper steam IDs and names and also fix some inaccuracies

### DIFF
--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -2472,7 +2472,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
       "mapper_name":"KreedZ, Spherix",
-      "mapper_steamid64":"76561198016516359, 76561198016516359"
+      "mapper_steamid64":"76561197997103423, 76561198016516359"
    },
    {
       "id":"363",

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -13,6 +13,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
       "mapper_name":"Reborn"
+      "mapper_steamid64":"76561197992700411"
    },
    {
       "id":"202",
@@ -52,6 +53,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
       "mapper_name":"pAtq"
+      "mapper_steamid64":"76561197997468889"
    },
    {
       "id":"206",
@@ -66,6 +68,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
       "mapper_name":"FoF"
+      "mapper_steamid64":"76561197991832101"
    },
    {
       "id":"597",
@@ -174,6 +177,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
       "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"216",
@@ -181,13 +185,15 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
       "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"217",
       "name":"bkz_nocturns_blue_gfix",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
-      "mapper_name":"Fran"
+      "mapper_name":"Levite"
+      "mapper_steamid64":"76561198031166668"
    },
    {
       "id":"827",
@@ -271,8 +277,8 @@
       "name":"kz_11735",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1333248573",
-      "mapper_name":"persona, geryuganshoop, GameChaos",
-      "mapper_steamid64":"76561198143205331, 76561198068278361, 76561198165203332"
+      "mapper_name":"persona, geryuganshoop",
+      "mapper_steamid64":"76561198143205331, 76561198068278361"
    },
    {
       "id":"226",
@@ -367,7 +373,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2233744660",
       "mapper_name":"Ownkruid, GnargarN",
-      "mapper_steamid64":"null, 76561198009902429"
+      "mapper_steamid64":"76561197985107159, 76561198009902429"
    },
    {
       "id":"232",
@@ -501,7 +507,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1947965934",
       "mapper_name":"eiRa, GameChaos",
-      "mapper_steamid64":"null, 76561198165203332"
+      "mapper_steamid64":"76561197977069783, 76561198165203332"
    },
    {
       "id":"646",
@@ -860,6 +866,7 @@
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
       "mapper_name":"vay"
+      "mapper_steamid64":"76561198131632059"
    },
    {
       "id":"898",
@@ -922,8 +929,8 @@
       "name":"kz_bhop_sakura",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2124488428",
-      "mapper_name":".yuka, murray",
-      "mapper_steamid64":"null, 76561198019551123"
+      "mapper_name":".yuka, TheIceTiger, murray",
+      "mapper_steamid64":"null, 76561198022081031, 76561198019551123"
    },
    {
       "id":"257",
@@ -1035,7 +1042,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627115733",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"823",
@@ -1201,7 +1208,8 @@
       "name":"kz_cartooncastle_go",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
-      "mapper_name":"Solid, karatekafer"
+      "mapper_name":"s0liD, karatekafer"
+      "mapper_steamid64":"76561197980460370, null"
    },
    {
       "id":"918",
@@ -1217,7 +1225,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116280",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"274",
@@ -1675,7 +1683,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116834",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"305",
@@ -1714,8 +1722,8 @@
       "name":"kz_date2",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406439108",
-      "mapper_name":"Solid, DropInMilk",
-      "mapper_steamid64":"null, 76561198033385282"
+      "mapper_name":"s0liD, DropInMilk",
+      "mapper_steamid64":"76561197980460370, 76561198033385282"
    },
    {
       "id":"308",
@@ -2215,7 +2223,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627117444",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"888",
@@ -2357,7 +2365,8 @@
       "name":"kz_genesis_go2",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
-      "mapper_name":"Fof"
+      "mapper_name":"FoF"
+      "mapper_steamid64":"76561197991832101"
    },
    {
       "id":"352",
@@ -2437,7 +2446,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118013",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"361",
@@ -2548,8 +2557,8 @@
       "name":"kz_grass_hard",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491359087",
-      "mapper_name":"Extremerz, GameChaos",
-      "mapper_steamid64":"null, 76561198165203332"
+      "mapper_name":"Extremerz",
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"369",
@@ -2676,6 +2685,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
       "mapper_name":"s0liD"
+      "mapper_steamid64":"76561197980460370"
    },
    {
       "id":"376",
@@ -2803,6 +2813,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
       "mapper_name":"s0lid, Spherix"
+      "mapper_steamid64":"76561197980460370, null"
    },
    {
       "id":"388",
@@ -2810,7 +2821,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
       "mapper_name":"s0lid, fl0w",
-      "mapper_steamid64":"null, 76561197991750093"
+      "mapper_steamid64":"76561197980460370, 76561197991750093"
    },
    {
       "id":"389",
@@ -2818,7 +2829,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
       "mapper_name":"s0lid, fl0w, DanZay",
-      "mapper_steamid64":"null, 76561197991750093, 76561197989817982"
+      "mapper_steamid64":"76561197980460370, 76561197991750093, 76561197989817982"
    },
    {
       "id":"390",
@@ -3201,6 +3212,7 @@
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
       "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"604",
@@ -4106,6 +4118,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
       "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"764",
@@ -4708,6 +4721,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
       "mapper_name":"s0lid"
+      "mapper_steamid64":"76561197980460370"
    },
    {
       "id":"856",
@@ -4746,6 +4760,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
       "mapper_name":"s0liD"
+      "mapper_steamid64":"76561197980460370"
    },
    {
       "id":"776",
@@ -5185,7 +5200,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118382",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"616",
@@ -5193,7 +5208,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118842",
       "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
    },
    {
       "id":"907",
@@ -5454,7 +5469,8 @@
       "name":"xc_nephilim",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
-      "mapper_name":"Ownkruid"
+      "mapper_name":"G O A"
+      "mapper_steamid64":"76561197990887735"
    },
    {
       "id":"537",

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -20,7 +20,7 @@
       "name":"bkz_bonus_z1",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509297499",
-      "mapper_name":"ZPrince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198047032125"
    },
    {
@@ -115,14 +115,16 @@
       "name":"bkz_goldbhop_csgo",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=245286254",
-      "mapper_name":"Sprite"
+      "mapper_name":"Sprite",
+      "mapper_steamid64":"76561197996878728"
    },
    {
       "id":"211",
       "name":"bkz_goldbhop_v2go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=343824673",
-      "mapper_name":"Sprite"
+      "mapper_name":"Sprite",
+      "mapper_steamid64":"76561197996878728"
    },
    {
       "id":"212",
@@ -230,7 +232,8 @@
       "name":"bkz_volcanohop",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=868101976",
-      "mapper_name":"Sprite"
+      "mapper_name":"Sprite",
+      "mapper_steamid64":"76561197996878728"
    },
    {
       "id":"820",
@@ -245,7 +248,7 @@
       "name":"kzpro_concrete_c02",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519499196",
-      "mapper_name":"ZPrince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198047032125"
    },
    {
@@ -253,8 +256,8 @@
       "name":"kzpro_gull_pidr_reborn",
       "difficulty":"5",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=642418824",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
+      "mapper_name":"OnlyFart, Gull",
+      "mapper_steamid64":"76561198014969050, 76561198137589262"
    },
    {
       "id":"737",
@@ -380,8 +383,8 @@
       "name":"kz_adv_cursedjourney",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=248583000",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
+      "mapper_name":"SinFuL, sn00p",
+      "mapper_steamid64":"76561197970838363, null"
    },
    {
       "id":"752",
@@ -650,8 +653,8 @@
       "name":"kz_asphyxiate",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1694955173",
-      "mapper_name":"sqrt, victoria248",
-      "mapper_steamid64":"null, 76561198026839022"
+      "mapper_name":"sqrt",
+      "mapper_steamid64":"76561198166088965"
    },
    {
       "id":"243",
@@ -722,7 +725,7 @@
       "name":"kz_aztec",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156057488",
-      "mapper_name":"Sinful",
+      "mapper_name":"SinFuL",
       "mapper_steamid64":"76561197970838363"
    },
    {
@@ -1193,7 +1196,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279210694",
       "mapper_name":"eiRa, Alouette",
-      "mapper_steamid64":"null, 76561198044981479"
+      "mapper_steamid64":"76561197977069783, 76561198044981479"
    },
    {
       "id":"864",
@@ -1255,7 +1258,8 @@
       "name":"kz_caulis_v2",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058093",
-      "mapper_name":"Millet"
+      "mapper_name":"Millet",
+      "mapper_steamid64":"76561197965115815"
    },
    {
       "id":"568",
@@ -1294,7 +1298,8 @@
       "name":"kz_cellblock_go2",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058850",
-      "mapper_name":"Millet"
+      "mapper_name":"Millet",
+      "mapper_steamid64":"76561197965115815"
    },
    {
       "id":"814",
@@ -1348,15 +1353,16 @@
       "name":"kz_chessblock",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=576215645",
-      "mapper_name":"AFlyingGuru"
+      "mapper_name":"aFlyingGuru",
+      "mapper_steamid64":"76561198047792076"
    },
    {
       "id":"283",
       "name":"kz_chinablock",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279166189",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
+      "mapper_name":"Lehmann, SinFuL",
+      "mapper_steamid64":"null, 76561197970838363"
    },
    {
       "id":"840",
@@ -1483,7 +1489,8 @@
       "name":"kz_communityjump3",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=659804813",
-      "mapper_name":"KZ Community"
+      "mapper_name":"george., Frosties",
+      "mapper_steamid64":"76561197975854215, 76561198115220426"
    },
    {
       "id":"291",
@@ -1491,7 +1498,7 @@
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=386875795",
       "mapper_name":"teh_grave, DropInMilk",
-      "mapper_steamid64":"null, 76561198033385282"
+      "mapper_steamid64":"76561197992255649, 76561198033385282"
    },
    {
       "id":"292",
@@ -1944,7 +1951,7 @@
       "name":"kz_edifice",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=930321498",
-      "mapper_name":"Crixzzi",
+      "mapper_name":"crixzzi",
       "mapper_steamid64":"76561198046307458"
    },
    {
@@ -1968,16 +1975,16 @@
       "name":"kz_emblem",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=489591399",
-      "mapper_name":"SinFul, Timmycakes",
-      "mapper_steamid64":"76561197970838363, 0"
+      "mapper_name":"Timmycakes, SinFuL",
+      "mapper_steamid64":"76561197996471054, 76561197970838363"
    },
    {
       "id":"327",
       "name":"kz_emblem_bonus",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491412109",
-      "mapper_name":"SinFul, Timmycakes",
-      "mapper_steamid64":"76561197970838363, 0"
+      "mapper_name":"Timmycakes, SinFuL",
+      "mapper_steamid64":"76561197996471054, 76561197970838363"
    },
    {
       "id":"838",
@@ -2128,7 +2135,8 @@
       "name":"kz_ext_bblocks",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352448183",
-      "mapper_name":"Extermerz"
+      "mapper_name":"Extremerz",
+      "mapper_steamid64":"76561197965479288"
    },
    {
       "id":"338",
@@ -2143,7 +2151,8 @@
       "name":"kz_failed_fastrun_rt",
       "difficulty":"5",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688361058",
-      "mapper_name":"0n1yF4r7"
+      "mapper_name":"OnlyFart",
+      "mapper_steamid64":"76561198014969050"
    },
    {
       "id":"692",
@@ -2231,7 +2240,7 @@
       "difficulty":"5",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2012561467",
       "mapper_name":"Deppy, persona",
-      "mapper_steamid64":"null, 76561198143205331"
+      "mapper_steamid64":"76561198107633657, 76561198143205331"
    },
    {
       "id":"345",
@@ -2437,8 +2446,8 @@
       "name":"kz_ggurk",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1139544827",
-      "mapper_name":"AFlyingGuru, Flow",
-      "mapper_steamid64":"null, 76561197991750093"
+      "mapper_name":"aFlyingGuru",
+      "mapper_steamid64":"76561198047792076"
    },
    {
       "id":"617",
@@ -2462,7 +2471,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
       "mapper_name":"KreedZ, Spherix",
-      "mapper_steamid64":"76561198016516359, null"
+      "mapper_steamid64":"76561198016516359, 76561198016516359"
    },
    {
       "id":"363",
@@ -2812,15 +2821,15 @@
       "name":"kz_j2s_cupblock_go_fix2",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
-      "mapper_name":"s0lid, Spherix",
-      "mapper_steamid64":"76561197980460370, null"
+      "mapper_name":"s0liD, Spherix",
+      "mapper_steamid64":"76561197980460370, 76561198016516359"
    },
    {
       "id":"388",
       "name":"kz_j2s_tetris_go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
-      "mapper_name":"s0lid, fl0w",
+      "mapper_name":"s0liD, fl0w",
       "mapper_steamid64":"76561197980460370, 76561197991750093"
    },
    {
@@ -2828,7 +2837,7 @@
       "name":"kz_j2s_westbl0ck",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
-      "mapper_name":"s0lid, fl0w, DanZay",
+      "mapper_name":"s0liD, fl0w, DanZay",
       "mapper_steamid64":"76561197980460370, 76561197991750093, 76561197989817982"
    },
    {
@@ -3092,8 +3101,8 @@
       "name":"kz_kzse_aztectemple",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=302894093",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
+      "mapper_name":"aegget, SinFuL",
+      "mapper_steamid64":"null, 76561197970838363"
    },
    {
       "id":"791",
@@ -3316,14 +3325,15 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1098716930",
       "mapper_name":"Kreedz, Spherix, GnagarN",
-      "mapper_steamid64":"76561197997103423, null, 76561198009902429"
+      "mapper_steamid64":"76561197997103423, 76561198016516359, 76561198009902429"
    },
    {
       "id":"408",
       "name":"kz_marblewalls_fixed",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=391298485",
-      "mapper_name":"Aaron"
+      "mapper_name":"Aaron",
+      "mapper_steamid64":"76561198036059696"
    },
    {
       "id":"587",
@@ -3346,7 +3356,7 @@
       "name":"kz_megabhop_v2",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667953480",
-      "mapper_name":"N1ghtFoX, Chuli"
+      "mapper_name":"inSaNe, N1ghtFoX, Chuli"
    },
    {
       "id":"411",
@@ -4006,8 +4016,8 @@
       "name":"kz_purgatory",
       "difficulty":"6",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1943903062",
-      "mapper_name":"Amber, htc, Rebmaa",
-      "mapper_steamid64":"null, null, 76561197970776455 "
+      "mapper_name":"Rebmaa",
+      "mapper_steamid64":"76561197970776455 "
    },
    {
       "id":"450",
@@ -4253,7 +4263,7 @@
       "name":"kz_sanctuary",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387095066",
-      "mapper_name":"Ace"
+      "mapper_name":"a$ce"
    },
    {
       "id":"469",
@@ -4276,8 +4286,8 @@
       "name":"kz_sandyhill_hoc",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068273",
-      "mapper_name":"SinFuL",
-      "mapper_steamid64":"76561197970838363"
+      "mapper_name":"Kangaroo, SinFuL",
+      "mapper_steamid64":"76561197977056063, 76561197970838363"
    },
    {
       "id":"886",
@@ -4467,7 +4477,8 @@
       "name":"kz_slide_purple_x",
       "difficulty":"5",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1842176999",
-      "mapper_name":"Kirman, PreFect"
+      "mapper_name":"Kirman, PreFect",
+      "mapper_steamid64":"76561197993076156, 76561198070700788"
    },
    {
       "id":"945",
@@ -4490,14 +4501,16 @@
       "name":"kz_slide_svn_extreme",
       "difficulty":"6",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1545821165",
-      "mapper_name":"SilverNinja"
+      "mapper_name":"SilverNinja",
+      "mapper_steamid64":"76561197963713381"
    },
    {
       "id":"704",
       "name":"kz_slide_svn_temple",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1866612534",
-      "mapper_name":"SilverNinja"
+      "mapper_name":"SilverNinja",
+      "mapper_steamid64":"76561197963713381"
    },
    {
       "id":"821",
@@ -4720,7 +4733,7 @@
       "name":"kz_streetblock_go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
-      "mapper_name":"s0lid",
+      "mapper_name":"s0liD",
       "mapper_steamid64":"76561197980460370"
    },
    {
@@ -4752,7 +4765,7 @@
       "name":"kz_sukblock_v2_fixed",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=511719435",
-      "mapper_name":"Suck' TearZ"
+      "mapper_name":"SuckY' TearZ"
    },
    {
       "id":"492",
@@ -4855,8 +4868,8 @@
       "name":"kz_sz_goldenbean",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279111456",
-      "mapper_name":"SinFuL",
-      "mapper_steamid64":"76561197970838363"
+      "mapper_name":"Kreedz, SinFuL",
+      "mapper_steamid64":"76561197997103423, 76561197970838363"
    },
    {
       "id":"500",
@@ -4895,8 +4908,8 @@
       "name":"kz_terablock",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=269563440",
-      "mapper_name":"SinFul, fl0w",
-      "mapper_steamid64":"null, 76561197991750093"
+      "mapper_name":"Kreedz, SinFuL",
+      "mapper_steamid64":"76561197997103423, 76561197970838363"
    },
    {
       "id":"816",
@@ -4972,7 +4985,8 @@
       "name":"kz_tradeblock_go",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352763435",
-      "mapper_name":"Millet"
+      "mapper_name":"Millet",
+      "mapper_steamid64":"76561197965115815"
    },
    {
       "id":"510",
@@ -5002,7 +5016,8 @@
       "id":"512",
       "name":"kz_tron_global",
       "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055395"
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055395",
+      "mapper_name":"><))'> FISHY"
    },
    {
       "id":"677",
@@ -5129,7 +5144,8 @@
       "name":"kz_waterhole",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1656359071",
-      "mapper_name":"lazovsky"
+      "mapper_name":"lazovsky",
+      "mapper_steamid64":"76561198003859123"
    },
    {
       "id":"777",
@@ -5223,7 +5239,8 @@
       "name":"kz_xtremeblock_v2",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156069128",
-      "mapper_name":"Chrizzy"
+      "mapper_name":"Chrizzy, s0liD",
+      "mapper_steamid64":"76561197975929287, 76561197980460370"
    },
    {
       "id":"574",
@@ -5254,7 +5271,7 @@
       "name":"kz_zhop_freestyle",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685863435",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5262,7 +5279,7 @@
       "name":"kz_zhop_function3",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=606199162",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5270,7 +5287,7 @@
       "name":"kz_zhop_son_fix",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580178806",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5294,7 +5311,7 @@
       "name":"kz_zxp_final4",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=632673660",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5302,7 +5319,7 @@
       "name":"kz_zxp_interstellar_v2",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667954510",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5310,7 +5327,7 @@
       "name":"kz_zxp_undia",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=639874816",
-      "mapper_name":"Zprince",
+      "mapper_name":"zPrince",
       "mapper_steamid64":"76561198151858167"
    },
    {
@@ -5415,7 +5432,7 @@
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1257230741",
       "mapper_name":"Dogers, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
+      "mapper_steamid64":"76561197986747461, 76561198002830622"
    },
    {
       "id":"560",
@@ -5485,7 +5502,8 @@
       "name":"xc_secret_valley_global_fix",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=451014834",
-      "mapper_name":"Sodan Tok"
+      "mapper_name":"Sodan Tok",
+      "mapper_steamid64":"76561198041171878"
    },
    {
       "id":"539",
@@ -5500,7 +5518,8 @@
       "name":"xc_supermario_go_gfix",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939578036",
-      "mapper_name":"Disturbed, Iconic"
+      "mapper_name":"SinFuL, Iconic",
+      "mapper_steamid64":"76561197970838363, null"
    },
    {
       "id":"541",

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -1,5512 +1,5513 @@
-[{
-		"id": "200",
-		"name": "bkz_apricity_v3",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1986459033",
-		"mapper_name": "Badges",
-		"mapper_steamid64": "76561197983438223"
-	},
-	{
-		"id": "201",
-		"name": "bkz_blackrockshooter_vzp",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
-		"mapper_name": "Reborn",
-		"mapper_steamid64": "76561197992700411"
-	},
-	{
-		"id": "202",
-		"name": "bkz_bonus_z1",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509297499",
-		"mapper_name": "ZPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "269",
-		"name": "bkz_cakewalk",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1613453363",
-		"mapper_name": "zPrince, GameChaos",
-		"mapper_steamid64": "76561198047032125, 76561198165203332"
-	},
-	{
-		"id": "203",
-		"name": "bkz_cauz_final",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535665232",
-		"mapper_name": "Cau",
-		"mapper_steamid64": "76561198041208499"
-	},
-	{
-		"id": "204",
-		"name": "bkz_cauz_short",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535645053",
-		"mapper_name": "Cau",
-		"mapper_steamid64": "76561198041208499"
-	},
-	{
-		"id": "205",
-		"name": "bkz_caves_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
-		"mapper_name": "pAtq",
-		"mapper_steamid64": "76561197997468889"
-	},
-	{
-		"id": "206",
-		"name": "bkz_cg_coldbhop",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=346170878",
-		"mapper_name": "DaMp"
-	},
-	{
-		"id": "207",
-		"name": "bkz_chillhop_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
-		"mapper_name": "FoF",
-		"mapper_steamid64": "76561197991832101"
-	},
-	{
-		"id": "597",
-		"name": "bkz_dontstop",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=449657758",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "208",
-		"name": "bkz_dydhop",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=784515943",
-		"mapper_name": "dydka",
-		"mapper_steamid64": "76561198010747369"
-	},
-	{
-		"id": "209",
-		"name": "bkz_evanstep",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=842652467",
-		"mapper_name": "Evanstep",
-		"mapper_steamid64": "76561198067339661"
-	},
-	{
-		"id": "551",
-		"name": "bkz_fapzor",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1304605829",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "542",
-		"name": "bkz_fear4",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1251914494",
-		"mapper_name": "Gull",
-		"mapper_steamid64": "76561198137589262"
-	},
-	{
-		"id": "210",
-		"name": "bkz_goldbhop_csgo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=245286254",
-		"mapper_name": "Sprite"
-	},
-	{
-		"id": "211",
-		"name": "bkz_goldbhop_v2go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=343824673",
-		"mapper_name": "Sprite"
-	},
-	{
-		"id": "212",
-		"name": "bkz_hellokitty_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688361403",
-		"mapper_name": "Kore"
-	},
-	{
-		"id": "213",
-		"name": "bkz_impulse",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418436480",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "661",
-		"name": "bkz_iota_v3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1734579951",
-		"mapper_name": "_Max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "767",
-		"name": "bkz_itz_h25l",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2076525905",
-		"mapper_name": "iTz",
-		"mapper_steamid64": "76561198104765796"
-	},
-	{
-		"id": "214",
-		"name": "bkz_levite_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667950111",
-		"mapper_name": "Levite",
-		"mapper_steamid64": "76561198031166668"
-	},
-	{
-		"id": "707",
-		"name": "bkz_lewlysex",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1904095585",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "215",
-		"name": "bkz_measure",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
-		"mapper_name": "ExtremerZ",
-		"mapper_steamid64": "76561197965479288"
-	},
-	{
-		"id": "216",
-		"name": "bkz_measure2_b03",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
-		"mapper_name": "ExtremerZ",
-		"mapper_steamid64": "76561197965479288"
-	},
-	{
-		"id": "217",
-		"name": "bkz_nocturns_blue_gfix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
-		"mapper_name": "Levite",
-		"mapper_steamid64": "76561198031166668"
-	},
-	{
-		"id": "827",
-		"name": "bkz_pogo",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2136367398",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "218",
-		"name": "bkz_sahara",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1840329522",
-		"mapper_name": "noko, GameChaos",
-		"mapper_steamid64": "76561198013202660, 76561198165203332"
-	},
-	{
-		"id": "221",
-		"name": "bkz_underground_crypt_v3",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491359928",
-		"mapper_name": "Yaznee"
-	},
-	{
-		"id": "222",
-		"name": "bkz_uninspired_trash",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053096",
-		"mapper_name": "Felicienne"
-	},
-	{
-		"id": "223",
-		"name": "bkz_volcanohop",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=868101976",
-		"mapper_name": "Sprite"
-	},
-	{
-		"id": "820",
-		"name": "bkz_zephyr_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2173494916",
-		"mapper_name": "crixzzi",
-		"mapper_steamid64": "76561198046307458"
-	},
-	{
-		"id": "224",
-		"name": "kzpro_concrete_c02",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519499196",
-		"mapper_name": "ZPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "225",
-		"name": "kzpro_gull_pidr_reborn",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=642418824",
-		"mapper_name": "Gull",
-		"mapper_steamid64": "76561198137589262"
-	},
-	{
-		"id": "737",
-		"name": "kzpro_justrun_sp",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1982407165",
-		"mapper_name": "Saicho",
-		"mapper_steamid64": "76561197995141366"
-	},
-	{
-		"id": "543",
-		"name": "kz_11342",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1155205561",
-		"mapper_name": "persona, geryuganshoop, GameChaos",
-		"mapper_steamid64": "76561198143205331, 76561198068278361, 76561198165203332"
-	},
-	{
-		"id": "566",
-		"name": "kz_11735",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1333248573",
-		"mapper_name": "persona, geryuganshoop",
-		"mapper_steamid64": "76561198143205331, 76561198068278361"
-	},
-	{
-		"id": "226",
-		"name": "kz_21loop_final_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=431789622",
-		"mapper_name": "Gemayue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "885",
-		"name": "kz_2fast",
-		"difficulty": "3",
-		"workshop_url": "http://steamcommunity.com/sharedfiles/filedetails/?id=636149777",
-		"mapper_name": "Gull",
-		"mapper_steamid64": "76561198137589262"
-	},
-	{
-		"id": "227",
-		"name": "kz_2seasons_spring_final",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1242447001",
-		"mapper_name": "Gemayue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "581",
-		"name": "kz_2seasons_winter_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=793414645",
-		"mapper_name": "Gemayue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "870",
-		"name": "kz_420b",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=527350529",
-		"mapper_name": "Gull",
-		"mapper_steamid64": "76561198137589262"
-	},
-	{
-		"id": "228",
-		"name": "kz_4u_nature",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1102436466",
-		"mapper_name": "Ivansky",
-		"mapper_steamid64": "76561198057742312"
-	},
-	{
-		"id": "229",
-		"name": "kz_7in1",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667950835",
-		"mapper_name": "Woozie"
-	},
-	{
-		"id": "862",
-		"name": "kz_8b1_brickngrass",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228982453",
-		"mapper_name": "8ball1, Fenikzz",
-		"mapper_steamid64": "76561198322296161, 76561198152002232"
-	},
-	{
-		"id": "738",
-		"name": "kz_aaaa",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1934946150",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "631",
-		"name": "kz_abandoned",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1581715482",
-		"mapper_name": "Lillen",
-		"mapper_steamid64": "76561198077858937"
-	},
-	{
-		"id": "230",
-		"name": "kz_abstruse_od2",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=841710228",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "231",
-		"name": "kz_adventure_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2233744660",
-		"mapper_name": "Ownkruid, GnargarN",
-		"mapper_steamid64": "76561197985107159, 76561198009902429"
-	},
-	{
-		"id": "232",
-		"name": "kz_adv_cursedjourney",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=248583000",
-		"mapper_name": "Sinful",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "752",
-		"name": "kz_aether_fix",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1901960163",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "642",
-		"name": "kz_afterlife",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1625094133",
-		"mapper_name": "Jony, Broiler",
-		"mapper_steamid64": "76561198000829729, 76561198136166348"
-	},
-	{
-		"id": "233",
-		"name": "kz_after_agitation_easy_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=793417352",
-		"mapper_name": "Gemayue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "234",
-		"name": "kz_agility_v2_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=392863247",
-		"mapper_name": "Aaron"
-	},
-	{
-		"id": "235",
-		"name": "kz_ahful",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580309446",
-		"mapper_name": "Ahful",
-		"mapper_steamid64": "76561198177735294"
-	},
-	{
-		"id": "236",
-		"name": "kz_akrh_warehouse_v2_gfix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939575987",
-		"mapper_name": "AssKicR"
-	},
-	{
-		"id": "929",
-		"name": "kz_alfama",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2327257272",
-		"mapper_name": "Rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "662",
-		"name": "kz_alfie",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1360984181",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "237",
-		"name": "kz_alice_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=478203041",
-		"mapper_name": "VVoodchip",
-		"mapper_steamid64": "76561198061948302"
-	},
-	{
-		"id": "759",
-		"name": "kz_alien_city",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2017349111",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "957",
-		"name": "kz_allure",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2423290876",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "922",
-		"name": "kz_alouette_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2347901033",
-		"mapper_name": "Alouette, nopey",
-		"mapper_steamid64": "76561198044981479, 76561198401447544"
-	},
-	{
-		"id": "881",
-		"name": "kz_alpha",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030049320",
-		"mapper_name": "Dima",
-		"mapper_steamid64": "76561198198062889"
-	},
-	{
-		"id": "882",
-		"name": "kz_altum_od",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2241212276",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "768",
-		"name": "kz_alt_aztec",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2069005326",
-		"mapper_name": "SinFuL, fucker",
-		"mapper_steamid64": "76561197970838363, 76561198243661942"
-	},
-	{
-		"id": "785",
-		"name": "kz_alt_cargo",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1947965934",
-		"mapper_name": "eiRa, GameChaos",
-		"mapper_steamid64": "76561197977069783, 76561198165203332"
-	},
-	{
-		"id": "646",
-		"name": "kz_amber_od",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1651410465",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "238",
-		"name": "kz_ancient_v3",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=576216273",
-		"mapper_name": "Verifyy",
-		"mapper_steamid64": "76561197995535364"
-	},
-	{
-		"id": "832",
-		"name": "kz_andromeda",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2193435024",
-		"mapper_name": "TheLlamaKing",
-		"mapper_steamid64": "76561197993284480"
-	},
-	{
-		"id": "830",
-		"name": "kz_angina_final",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2182136940",
-		"mapper_name": "daolang, temmie",
-		"mapper_steamid64": "76561198814294487,  76561198137502865"
-	},
-	{
-		"id": "923",
-		"name": "kz_anotherclimbmap",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2271036340",
-		"mapper_name": "therapysession, nopey",
-		"mapper_steamid64": "76561198012265008, 76561198401447544"
-	},
-	{
-		"id": "826",
-		"name": "kz_antharas",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2137813215",
-		"mapper_name": "Fksch",
-		"mapper_steamid64": "76561198142682783"
-	},
-	{
-		"id": "803",
-		"name": "kz_antigeneric",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2136461557",
-		"mapper_name": "rush2sk8, EchoFrost",
-		"mapper_steamid64": "76561198082904691, 76561198121144282"
-	},
-	{
-		"id": "805",
-		"name": "kz_antimony",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2027793498",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "914",
-		"name": "kz_antiquity",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2275579584",
-		"mapper_name": "JustErroR^, GameChaos",
-		"mapper_steamid64": "76561198150858529, 76561198165203332"
-	},
-	{
-		"id": "801",
-		"name": "kz_anus",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2134749919",
-		"mapper_name": "suna",
-		"mapper_steamid64": "76561198845462726"
-	},
-	{
-		"id": "647",
-		"name": "kz_arbitrary_words",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1658130511",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "239",
-		"name": "kz_arcadium",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1178668090",
-		"mapper_name": "ivansky",
-		"mapper_steamid64": "76561198057742312"
-	},
-	{
-		"id": "629",
-		"name": "kz_arcturus",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1587362542",
-		"mapper_name": "Espoon",
-		"mapper_steamid64": "76561198055373574"
-	},
-	{
-		"id": "939",
-		"name": "kz_armored_core",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381741747",
-		"mapper_name": "J3wDice",
-		"mapper_steamid64": "76561198208729343"
-	},
-	{
-		"id": "240",
-		"name": "kz_arrebol",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=846831175",
-		"mapper_name": "Nthng",
-		"mapper_steamid64": "76561198124649132"
-	},
-	{
-		"id": "241",
-		"name": "kz_ascend_hv",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357729700",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "921",
-		"name": "kz_ashen",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2308615315",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "242",
-		"name": "kz_asphyxiate",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1694955173",
-		"mapper_name": "sqrt, victoria248",
-		"mapper_steamid64": "null, 76561198026839022"
-	},
-	{
-		"id": "243",
-		"name": "kz_asteroid_field_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=333421749",
-		"mapper_name": "SoUlFaThEr",
-		"mapper_steamid64": "76561197965266419"
-	},
-	{
-		"id": "567",
-		"name": "kz_atelectasis_sct",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1887458950",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "684",
-		"name": "kz_athena",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753252198",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198044055747"
-	},
-	{
-		"id": "847",
-		"name": "kz_atlantis_od3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996497943",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "244",
-		"name": "kz_autobadges",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509624370",
-		"mapper_name": "Badges",
-		"mapper_steamid64": "76561197983438223"
-	},
-	{
-		"id": "663",
-		"name": "kz_autumn_valley_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1747171037",
-		"mapper_name": "iBUYFL0WER Birgit",
-		"mapper_steamid64": "76561198078014747"
-	},
-	{
-		"id": "815",
-		"name": "kz_avalon",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2191500128",
-		"mapper_name": "Michael",
-		"mapper_steamid64": "76561198004229810"
-	},
-	{
-		"id": "245",
-		"name": "kz_avoria",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1199062647",
-		"mapper_name": "Smex",
-		"mapper_steamid64": "76561197961558198"
-	},
-	{
-		"id": "246",
-		"name": "kz_aztec",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156057488",
-		"mapper_name": "Sinful",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "635",
-		"name": "kz_azure",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1563199395",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "664",
-		"name": "kz_babycat_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1708424560",
-		"mapper_name": "Schrødna ",
-		"mapper_steamid64": "76561198067192262"
-	},
-	{
-		"id": "598",
-		"name": "kz_bacho",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1481626092",
-		"mapper_name": "Sodawater",
-		"mapper_steamid64": "76561198180483758"
-	},
-	{
-		"id": "871",
-		"name": "kz_backwards",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2236890476",
-		"mapper_name": "Emzatin",
-		"mapper_steamid64": "76561198393292046"
-	},
-	{
-		"id": "247",
-		"name": "kz_bananaysoda_v2",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2156821612",
-		"mapper_name": "Jony, fucker",
-		"mapper_steamid64": "76561198000829729, 76561198243661942"
-	},
-	{
-		"id": "739",
-		"name": "kz_banjo",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753959953",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "248",
-		"name": "kz_basicnoon",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=379026993",
-		"mapper_name": "RVE",
-		"mapper_steamid64": "76561198014015385"
-	},
-	{
-		"id": "249",
-		"name": "kz_basics_b02",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519499813",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "599",
-		"name": "kz_baxter",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1366794864",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "834",
-		"name": "kz_beanguy_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2197490213",
-		"mapper_name": "shnart, Nopey",
-		"mapper_steamid64": "76561198045654331, 76561198401447544"
-	},
-	{
-		"id": "250",
-		"name": "kz_beginnerblock_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156057667",
-		"mapper_name": "Ovi"
-	},
-	{
-		"id": "916",
-		"name": "kz_betapmaps",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2325269071",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "251",
-		"name": "kz_betterdunjun",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=523852277",
-		"mapper_name": "DannyE",
-		"mapper_steamid64": "76561198178232629"
-	},
-	{
-		"id": "894",
-		"name": "kz_bhop_badges2",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1899371128",
-		"mapper_name": "badges, ρ",
-		"mapper_steamid64": "76561197983438223, 76561198002830622"
-	},
-	{
-		"id": "665",
-		"name": "kz_bhop_badges3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1726813996",
-		"mapper_name": "badges, ρ",
-		"mapper_steamid64": "76561197983438223, 76561198002830622"
-	},
-	{
-		"id": "691",
-		"name": "kz_bhop_benchmark",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1776449850",
-		"mapper_name": "badges, ρ",
-		"mapper_steamid64": "76561197983438223, 76561198002830622"
-	},
-	{
-		"id": "634",
-		"name": "kz_bhop_dusk_go",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1617628780",
-		"mapper_name": "CraizZ, ρ",
-		"mapper_steamid64": "76561197993271570, 76561198002830622"
-	},
-	{
-		"id": "252",
-		"name": "kz_bhop_essence",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
-		"mapper_name": "vay",
-		"mapper_steamid64": "76561198131632059"
-	},
-	{
-		"id": "898",
-		"name": "kz_bhop_koki_niwa",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2303161020",
-		"mapper_name": "noko",
-		"mapper_steamid64": "76561198013202660"
-	},
-	{
-		"id": "254",
-		"name": "kz_bhop_lj",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406077055",
-		"mapper_name": "badges",
-		"mapper_steamid64": "76561197983438223"
-	},
-	{
-		"id": "740",
-		"name": "kz_bhop_lucid",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1871085547",
-		"mapper_name": "keyuu, ρ",
-		"mapper_steamid64": "76561198003202977, 76561198002830622"
-	},
-	{
-		"id": "928",
-		"name": "kz_bhop_monsterjam",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2272849539",
-		"mapper_name": "Aoki, GameChaos",
-		"mapper_steamid64": "null, 76561198165203332"
-	},
-	{
-		"id": "582",
-		"name": "kz_bhop_mosaic_od2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=646510868",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "256",
-		"name": "kz_bhop_northface",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=642020842",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "544",
-		"name": "kz_bhop_nothing_go",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1204096299",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "794",
-		"name": "kz_bhop_sakura",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2124488428",
-		"mapper_name": ".yuka, TheIceTiger, murray",
-		"mapper_steamid64": "null, 76561198022081031, 76561198019551123"
-	},
-	{
-		"id": "257",
-		"name": "kz_bhop_skyworld_go",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=678315907",
-		"mapper_name": "ρ, Orbit",
-		"mapper_steamid64": "76561198002830622, 76561198057269402"
-	},
-	{
-		"id": "258",
-		"name": "kz_bhop_watertemple",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519457034",
-		"mapper_name": "Daza, SoUlFaThEr, zPrince",
-		"mapper_steamid64": "76561198007996091, 76561197965266419, 76561198047032125"
-	},
-	{
-		"id": "600",
-		"name": "kz_bhop_zenith",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=715243400",
-		"mapper_name": "Zorb, Cyclo",
-		"mapper_steamid64": "76561198144259350, 76561198024466262"
-	},
-	{
-		"id": "624",
-		"name": "kz_bible_black",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1617624549",
-		"mapper_name": "victoria248",
-		"mapper_steamid64": "76561198026839022"
-	},
-	{
-		"id": "920",
-		"name": "kz_bigcastle",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2303795750",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "769",
-		"name": "kz_binseebak",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2096008736",
-		"mapper_name": "L1nus",
-		"mapper_steamid64": "76561198835361052"
-	},
-	{
-		"id": "259",
-		"name": "kz_bionic",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=598309769",
-		"mapper_name": "Zorb",
-		"mapper_steamid64": "76561198144259350"
-	},
-	{
-		"id": "879",
-		"name": "kz_birrita_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240515420",
-		"mapper_name": "HermeticA",
-		"mapper_steamid64": "76561198082476569"
-	},
-	{
-		"id": "741",
-		"name": "kz_bir_dont_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2002208768",
-		"mapper_name": "Bird",
-		"mapper_steamid64": "76561198061987188"
-	},
-	{
-		"id": "641",
-		"name": "kz_blackness",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1582682050",
-		"mapper_name": "Jony",
-		"mapper_steamid64": "76561198000829729"
-	},
-	{
-		"id": "260",
-		"name": "kz_blatherskite_v1",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1201400569",
-		"mapper_name": "DannyE",
-		"mapper_steamid64": "76561198178232629"
-	},
-	{
-		"id": "261",
-		"name": "kz_blindcity_easy_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=673671001",
-		"mapper_name": "GemaYue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "262",
-		"name": "kz_blindcity_hard_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=450945426",
-		"mapper_name": "GemaYue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "618",
-		"name": "kz_blocks2006",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627115733",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "823",
-		"name": "kz_bloodline",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2169096895",
-		"mapper_name": "Makis",
-		"mapper_steamid64": "76561198201492663"
-	},
-	{
-		"id": "263",
-		"name": "kz_bluehop_mq",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1241443665",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "264",
-		"name": "kz_bluerace_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667952586",
-		"mapper_name": "tr4mp"
-	},
-	{
-		"id": "941",
-		"name": "kz_bluuu",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2416991755",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "601",
-		"name": "kz_bombu",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=742494584",
-		"mapper_name": "Bombu",
-		"mapper_steamid64": "76561198217095940"
-	},
-	{
-		"id": "849",
-		"name": "kz_boomblock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2206472013",
-		"mapper_name": "Szwagi",
-		"mapper_steamid64": "76561198857828380"
-	},
-	{
-		"id": "796",
-		"name": "kz_bounce",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2118830049",
-		"mapper_name": "Makis",
-		"mapper_steamid64": "76561198201492663"
-	},
-	{
-		"id": "265",
-		"name": "kz_breezeblocks",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=898027127",
-		"mapper_name": "BreeZ",
-		"mapper_steamid64": "76561198339346625"
-	},
-	{
-		"id": "266",
-		"name": "kz_brickblock_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=621434939",
-		"mapper_name": "masque, DanZay",
-		"mapper_steamid64": "76561197979436335, 76561197989817982"
-	},
-	{
-		"id": "926",
-		"name": "kz_bridge17_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2309106000",
-		"mapper_name": "pr3da, _max",
-		"mapper_steamid64": "76561198021246024, 76561198083065598"
-	},
-	{
-		"id": "267",
-		"name": "kz_brightblock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=653272914",
-		"mapper_name": "bboc",
-		"mapper_steamid64": "76561198000159327"
-	},
-	{
-		"id": "268",
-		"name": "kz_buildings_final",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406077441",
-		"mapper_name": "Vypur",
-		"mapper_steamid64": "76561198027553039"
-	},
-	{
-		"id": "895",
-		"name": "kz_burnished",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2120360302",
-		"mapper_name": "L1nus",
-		"mapper_steamid64": "76561198835361052"
-	},
-	{
-		"id": "911",
-		"name": "kz_byrem",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2327576026",
-		"mapper_name": "Rem, Antosha*",
-		"mapper_steamid64": "76561198072336874, 76561197974898839"
-	},
-	{
-		"id": "686",
-		"name": "kz_cabin_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240379784",
-		"mapper_name": "mjb",
-		"mapper_steamid64": "76561198093921774"
-	},
-	{
-		"id": "270",
-		"name": "kz_camembert",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=808050906",
-		"mapper_name": "BOWql",
-		"mapper_steamid64": "76561198190304705"
-	},
-	{
-		"id": "271",
-		"name": "kz_canyon",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=621630951",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "583",
-		"name": "kz_carbon",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1398723898",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "798",
-		"name": "kz_cargo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279210694",
-		"mapper_name": "eiRa, Alouette",
-		"mapper_steamid64": "null, 76561198044981479"
-	},
-	{
-		"id": "864",
-		"name": "kz_carp_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2241460284",
-		"mapper_name": "Andi, Nopey",
-		"mapper_steamid64": "76561198156668976, 76561198401447544"
-	},
-	{
-		"id": "272",
-		"name": "kz_cartooncastle_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
-		"mapper_name": "s0liD, karatekafer",
-		"mapper_steamid64": "76561197980460370, null"
-	},
-	{
-		"id": "918",
-		"name": "kz_cascade_v4",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2356578123",
-		"mapper_name": "KingGambit",
-		"mapper_steamid64": "76561198023829871"
-	},
-	{
-		"id": "621",
-		"name": "kz_castlehops_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627116280",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "274",
-		"name": "kz_cataclysm",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370545981",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "275",
-		"name": "kz_catalyst_gfix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939576543",
-		"mapper_name": "umbrella"
-	},
-	{
-		"id": "276",
-		"name": "kz_catharsis_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=615332047",
-		"mapper_name": "kaldren.",
-		"mapper_steamid64": "76561197972347749"
-	},
-	{
-		"id": "277",
-		"name": "kz_caulis_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156058093",
-		"mapper_name": "Millet"
-	},
-	{
-		"id": "568",
-		"name": "kz_cdr_myst",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1391753126",
-		"mapper_name": "Dunk",
-		"mapper_steamid64": "76561197987174004"
-	},
-	{
-		"id": "627",
-		"name": "kz_cdr_rustenborg",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1401830672",
-		"mapper_name": "Dunk",
-		"mapper_steamid64": "76561197987174004"
-	},
-	{
-		"id": "569",
-		"name": "kz_cdr_slash_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1391789057",
-		"mapper_name": "Dunk",
-		"mapper_steamid64": "76561197987174004"
-	},
-	{
-		"id": "760",
-		"name": "kz_celestial",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2059174492",
-		"mapper_name": "mjb",
-		"mapper_steamid64": "76561198093921774"
-	},
-	{
-		"id": "278",
-		"name": "kz_cellblock_go2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156058850",
-		"mapper_name": "Millet"
-	},
-	{
-		"id": "814",
-		"name": "kz_cereal",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2176136694",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "279",
-		"name": "kz_cg_brick_rmk",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688171253",
-		"mapper_name": "InseN"
-	},
-	{
-		"id": "280",
-		"name": "kz_cg_lighthops_go",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352286796",
-		"mapper_name": "Mentalo, OldHead",
-		"mapper_steamid64": "null, 76561198009989298"
-	},
-	{
-		"id": "619",
-		"name": "kz_checkmate",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1535993215",
-		"mapper_name": "GameChaos",
-		"mapper_steamid64": "76561198165203332"
-	},
-	{
-		"id": "848",
-		"name": "kz_cheese",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2204525929",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "281",
-		"name": "kz_cheetos_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2234432420",
-		"mapper_name": "pe, Nopey",
-		"mapper_steamid64": "76561198212205417, 76561198401447544"
-	},
-	{
-		"id": "282",
-		"name": "kz_chessblock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=576215645",
-		"mapper_name": "AFlyingGuru"
-	},
-	{
-		"id": "283",
-		"name": "kz_chinablock",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279166189",
-		"mapper_name": "Sinful",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "840",
-		"name": "kz_chloroplast",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2194393186",
-		"mapper_name": "Plastyc",
-		"mapper_steamid64": "76561199024218227"
-	},
-	{
-		"id": "742",
-		"name": "kz_choka_fix",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1933623975",
-		"mapper_name": "JJ",
-		"mapper_steamid64": "76561198167125526"
-	},
-	{
-		"id": "897",
-		"name": "kz_chopchop",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187656713",
-		"mapper_name": "Sehk",
-		"mapper_steamid64": "76561198037724970"
-	},
-	{
-		"id": "284",
-		"name": "kz_christmas_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=669198796",
-		"mapper_name": "geryuganshoop",
-		"mapper_steamid64": "76561198068278361"
-	},
-	{
-		"id": "892",
-		"name": "kz_chrysoprase",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2237697111",
-		"mapper_name": "Michael",
-		"mapper_steamid64": "76561198004229810"
-	},
-	{
-		"id": "902",
-		"name": "kz_chunky_peanut_butter",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259665094",
-		"mapper_name": "rov",
-		"mapper_steamid64": "76561198132236283"
-	},
-	{
-		"id": "636",
-		"name": "kz_citadel",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1546644939",
-		"mapper_name": "aleiux",
-		"mapper_steamid64": "76561198090798444"
-	},
-	{
-		"id": "753",
-		"name": "kz_civilizations",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2034478444",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "285",
-		"name": "kz_cliffhanger_go_global",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=504851319",
-		"mapper_name": "Blind",
-		"mapper_steamid64": "76561198152317855"
-	},
-	{
-		"id": "825",
-		"name": "kz_coastline_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2171603497",
-		"mapper_name": "Steelo, Nopey",
-		"mapper_steamid64": "76561198279205361, 76561198401447544"
-	},
-	{
-		"id": "286",
-		"name": "kz_colorcode",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=528597060",
-		"mapper_name": "schm0ftie",
-		"mapper_steamid64": "76561197983561860"
-	},
-	{
-		"id": "287",
-		"name": "kz_colors_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=325027910",
-		"mapper_name": "Wally",
-		"mapper_steamid64": "76561197967777192"
-	},
-	{
-		"id": "288",
-		"name": "kz_combobreaker",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=908525075",
-		"mapper_name": "GameChaos",
-		"mapper_steamid64": "76561198165203332"
-	},
-	{
-		"id": "289",
-		"name": "kz_combohop_c02",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519498732",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "570",
-		"name": "kz_comboya",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1256315105",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "290",
-		"name": "kz_communityjump3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=659804813",
-		"mapper_name": "KZ Community"
-	},
-	{
-		"id": "291",
-		"name": "kz_complex",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=386875795",
-		"mapper_name": "teh_grave, DropInMilk",
-		"mapper_steamid64": "null, 76561198033385282"
-	},
-	{
-		"id": "292",
-		"name": "kz_comp_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053614",
-		"mapper_name": "ella",
-		"mapper_steamid64": "76561198069465729"
-	},
-	{
-		"id": "293",
-		"name": "kz_concept",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=903732207",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "294",
-		"name": "kz_concretejungle",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=506427184",
-		"mapper_name": "rev",
-		"mapper_steamid64": "76561197981308142"
-	},
-	{
-		"id": "650",
-		"name": "kz_conifer",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1699121278",
-		"mapper_name": "victoria248, GameChaos",
-		"mapper_steamid64": "76561198026839022, 76561198165203332"
-	},
-	{
-		"id": "295",
-		"name": "kz_conrun_mq",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=381648804",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "296",
-		"name": "kz_conrun_scrub",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=382262763",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "297",
-		"name": "kz_conspiracy",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=896555313",
-		"mapper_name": "Jakobe",
-		"mapper_steamid64": "76561198072850237"
-	},
-	{
-		"id": "298",
-		"name": "kz_construction",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=499184114",
-		"mapper_name": "finckelton",
-		"mapper_steamid64": "76561198039388458"
-	},
-	{
-		"id": "683",
-		"name": "kz_continuum",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1464119184",
-		"mapper_name": "Crash",
-		"mapper_steamid64": "76561197981212562"
-	},
-	{
-		"id": "552",
-		"name": "kz_coronado_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1381132298",
-		"mapper_name": "Cyclo",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "602",
-		"name": "kz_correguachin_reisido",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187796868",
-		"mapper_name": "Shendal",
-		"mapper_steamid64": "76561198225775664"
-	},
-	{
-		"id": "545",
-		"name": "kz_cousucks",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1241648205",
-		"mapper_name": "Krushed",
-		"mapper_steamid64": "76561197966948458"
-	},
-	{
-		"id": "943",
-		"name": "kz_cranking_the_hog",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381788599",
-		"mapper_name": "rov",
-		"mapper_steamid64": "76561198132236283"
-	},
-	{
-		"id": "828",
-		"name": "kz_crash_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2163399474",
-		"mapper_name": "Alouette, nopey",
-		"mapper_steamid64": "76561198044981479, 76561198401447544"
-	},
-	{
-		"id": "299",
-		"name": "kz_cratespeed",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=689965741",
-		"mapper_name": "ruben",
-		"mapper_steamid64": "76561198100183392"
-	},
-	{
-		"id": "300",
-		"name": "kz_crate_delight_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491405849",
-		"mapper_name": "SoUlFaThEr, zPrince",
-		"mapper_steamid64": "76561197965266419, 76561198047032125"
-	},
-	{
-		"id": "301",
-		"name": "kz_crypt_final",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=528128872",
-		"mapper_name": "Ryborg",
-		"mapper_steamid64": "76561198101913104"
-	},
-	{
-		"id": "302",
-		"name": "kz_crysis",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387238555",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "953",
-		"name": "kz_cuberunfast",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2420438992",
-		"mapper_name": "DannyE",
-		"mapper_steamid64": "76561198178232629"
-	},
-	{
-		"id": "303",
-		"name": "kz_custos",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1135144334",
-		"mapper_name": "xq, GameChaos",
-		"mapper_steamid64": "76561198094382485, 76561198165203332"
-	},
-	{
-		"id": "712",
-		"name": "kz_cyberspace_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996119569",
-		"mapper_name": "Charon",
-		"mapper_steamid64": "76561197979938663"
-	},
-	{
-		"id": "304",
-		"name": "kz_cyb_adrenaline_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1780391218",
-		"mapper_name": "cybur, masque",
-		"mapper_steamid64": "76561198062384407, 76561197979436335"
-	},
-	{
-		"id": "553",
-		"name": "kz_dakow",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1278987653",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "613",
-		"name": "kz_dale",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627116834",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "305",
-		"name": "kz_dam",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=647694230",
-		"mapper_name": "pr3da",
-		"mapper_steamid64": "76561198021246024"
-	},
-	{
-		"id": "306",
-		"name": "kz_daniel",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=416827844",
-		"mapper_name": "Khaleese",
-		"mapper_steamid64": "76561198123676539"
-	},
-	{
-		"id": "770",
-		"name": "kz_dank_stacks",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2075152351",
-		"mapper_name": "DankD",
-		"mapper_steamid64": "76561198039728576"
-	},
-	{
-		"id": "924",
-		"name": "kz_dark_fury",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2380315439",
-		"mapper_name": "sn00p, ρ",
-		"mapper_steamid64": "null, 76561198002830622"
-	},
-	{
-		"id": "307",
-		"name": "kz_date2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406439108",
-		"mapper_name": "s0liD, DropInMilk",
-		"mapper_steamid64": "76561197980460370, 76561198033385282"
-	},
-	{
-		"id": "308",
-		"name": "kz_default",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=382377001",
-		"mapper_name": "DropinMilk",
-		"mapper_steamid64": "76561198033385282"
-	},
-	{
-		"id": "622",
-		"name": "kz_dejavu",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1539800895",
-		"mapper_name": "Fnugz",
-		"mapper_steamid64": "76561198012891563"
-	},
-	{
-		"id": "811",
-		"name": "kz_delphinium",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2145751608",
-		"mapper_name": "Michael",
-		"mapper_steamid64": "76561198004229810"
-	},
-	{
-		"id": "309",
-		"name": "kz_depot",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=738046973",
-		"mapper_name": "f3vo",
-		"mapper_steamid64": "76561198040677227"
-	},
-	{
-		"id": "554",
-		"name": "kz_dethroned",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1295359223",
-		"mapper_name": "Cyclo",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "310",
-		"name": "kz_de_bhop",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509624659"
-	},
-	{
-		"id": "651",
-		"name": "kz_diajonal",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1626046474",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "311",
-		"name": "kz_dimensions_v1",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491411804",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "312",
-		"name": "kz_district_d01",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=421427380",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "908",
-		"name": "kz_divided",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2330433609",
-		"mapper_name": "J3wDice",
-		"mapper_steamid64": "76561198208729343"
-	},
-	{
-		"id": "925",
-		"name": "kz_dontjump",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2276652300",
-		"mapper_name": "Emzatin",
-		"mapper_steamid64": "76561198393292046"
-	},
-	{
-		"id": "313",
-		"name": "kz_doubletake",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491377297",
-		"mapper_name": "BeastF",
-		"mapper_steamid64": "76561197992587981"
-	},
-	{
-		"id": "314",
-		"name": "kz_doveen",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=391996291",
-		"mapper_name": "DoveeN",
-		"mapper_steamid64": "76561198033299991"
-	},
-	{
-		"id": "315",
-		"name": "kz_drops_od",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=631559848",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "937",
-		"name": "kz_drunkards",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2422272884",
-		"mapper_name": "Plastyc",
-		"mapper_steamid64": "76561199024218227"
-	},
-	{
-		"id": "316",
-		"name": "kz_dryness",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=611091154",
-		"mapper_name": "pr3da",
-		"mapper_steamid64": "76561198021246024"
-	},
-	{
-		"id": "317",
-		"name": "kz_duality_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1851066208",
-		"mapper_name": "VVoodchip, Zach47",
-		"mapper_steamid64": "76561198061948302, 76561197983014207"
-	},
-	{
-		"id": "318",
-		"name": "kz_dungeon",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515635506",
-		"mapper_name": "RyBorg",
-		"mapper_steamid64": "76561198101913104"
-	},
-	{
-		"id": "850",
-		"name": "kz_dust",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187288428",
-		"mapper_name": "L1nus",
-		"mapper_steamid64": "76561198835361052"
-	},
-	{
-		"id": "319",
-		"name": "kz_dvn_cube_fixed",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498765580",
-		"mapper_name": "DoveeN",
-		"mapper_steamid64": "76561198033299991"
-	},
-	{
-		"id": "320",
-		"name": "kz_dvn_dull",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=483073135",
-		"mapper_name": "DoveeN",
-		"mapper_steamid64": "76561198033299991"
-	},
-	{
-		"id": "321",
-		"name": "kz_dvn_redcarpet",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=605822998",
-		"mapper_name": "DoveeN",
-		"mapper_steamid64": "76561198033299991"
-	},
-	{
-		"id": "713",
-		"name": "kz_dyd_ladderjumps",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1653452291",
-		"mapper_name": "dydka, GameChaos",
-		"mapper_steamid64": "76561198010747369, 76561198165203332"
-	},
-	{
-		"id": "322",
-		"name": "kz_dzy_beyond_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=454227310",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "323",
-		"name": "kz_dzy_reach_v2",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=673887976",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "324",
-		"name": "kz_ea_beneath_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=338561631",
-		"mapper_name": "rad0n, old head",
-		"mapper_steamid64": "null, 76561198009989298"
-	},
-	{
-		"id": "873",
-		"name": "kz_echo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259659098",
-		"mapper_name": "mjb",
-		"mapper_steamid64": "76561198093921774"
-	},
-	{
-		"id": "325",
-		"name": "kz_edifice",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=930321498",
-		"mapper_name": "Crixzzi",
-		"mapper_steamid64": "76561198046307458"
-	},
-	{
-		"id": "667",
-		"name": "kz_edp445",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1755737510",
-		"mapper_name": "victoria248",
-		"mapper_steamid64": "76561198026839022"
-	},
-	{
-		"id": "623",
-		"name": "kz_egyptianbox",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1576706552",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "326",
-		"name": "kz_emblem",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=489591399",
-		"mapper_name": "SinFul, Timmycakes",
-		"mapper_steamid64": "76561197970838363, 0"
-	},
-	{
-		"id": "327",
-		"name": "kz_emblem_bonus",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491412109",
-		"mapper_name": "SinFul, Timmycakes",
-		"mapper_steamid64": "76561197970838363, 0"
-	},
-	{
-		"id": "838",
-		"name": "kz_emptiness",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2203626680",
-		"mapper_name": "SneakY",
-		"mapper_steamid64": "76561198251129150"
-	},
-	{
-		"id": "328",
-		"name": "kz_ephemeral",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=692077375",
-		"mapper_name": "Tapzie",
-		"mapper_steamid64": "76561198122678894"
-	},
-	{
-		"id": "584",
-		"name": "kz_epiphany_v2",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1386147078",
-		"mapper_name": "Cyclo",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "329",
-		"name": "kz_epusbridge",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=303863578",
-		"mapper_name": "Deepus",
-		"mapper_steamid64": "76561197976153012"
-	},
-	{
-		"id": "930",
-		"name": "kz_erbajerb",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2304761102",
-		"mapper_name": "Birgit",
-		"mapper_steamid64": "76561198078014747"
-	},
-	{
-		"id": "330",
-		"name": "kz_erinome",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=568096729",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "331",
-		"name": "kz_eros_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=791910412",
-		"mapper_name": "finckelton, Kiwi",
-		"mapper_steamid64": "76561198039388458, 76561198077353609"
-	},
-	{
-		"id": "546",
-		"name": "kz_erratum_v2",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1170612689",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "936",
-		"name": "kz_eudora",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2312833379",
-		"mapper_name": "nowimime",
-		"mapper_steamid64": "76561198077383803"
-	},
-	{
-		"id": "585",
-		"name": "kz_eventide",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1382667484",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "799",
-		"name": "kz_everything",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2069925634",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "714",
-		"name": "kz_evilcorp",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1904796339",
-		"mapper_name": "Magier",
-		"mapper_steamid64": "76561198103471850"
-	},
-	{
-		"id": "332",
-		"name": "kz_excape",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406079956",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "333",
-		"name": "kz_excavate_b",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1440554662",
-		"mapper_name": "Badges",
-		"mapper_steamid64": "76561197983438223"
-	},
-	{
-		"id": "831",
-		"name": "kz_exemplum_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228224629",
-		"mapper_name": "Makis",
-		"mapper_steamid64": "76561198201492663"
-	},
-	{
-		"id": "334",
-		"name": "kz_exoteric",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=380505617",
-		"mapper_name": "Energy",
-		"mapper_steamid64": "76561198084022373"
-	},
-	{
-		"id": "335",
-		"name": "kz_experiment",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=398489890",
-		"mapper_name": "TheWhaleMan",
-		"mapper_steamid64": "76561198064508818"
-	},
-	{
-		"id": "336",
-		"name": "kz_exps_cursedjourney",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=525288912",
-		"mapper_name": "SinFul",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "337",
-		"name": "kz_ext_bblocks",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352448183",
-		"mapper_name": "Extermerz"
-	},
-	{
-		"id": "338",
-		"name": "kz_fabrik",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=221328962",
-		"mapper_name": "Snorres",
-		"mapper_steamid64": "76561197986556153"
-	},
-	{
-		"id": "339",
-		"name": "kz_failed_fastrun_rt",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688361058",
-		"mapper_name": "0n1yF4r7"
-	},
-	{
-		"id": "692",
-		"name": "kz_farm_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1750701302",
-		"mapper_name": "Chris, GameChaos",
-		"mapper_steamid64": "76561198044472964, 76561198165203332"
-	},
-	{
-		"id": "693",
-		"name": "kz_fas2map",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1699101066",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "340",
-		"name": "kz_fastcombomap",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=760052560",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "603",
-		"name": "kz_fastmap",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1448528308",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "341",
-		"name": "kz_fatigue_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=375133191",
-		"mapper_name": "Energy",
-		"mapper_steamid64": "76561198084022373"
-	},
-	{
-		"id": "342",
-		"name": "kz_fikablock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=674086581",
-		"mapper_name": "Jmonsted",
-		"mapper_steamid64": "76561198071182150"
-	},
-	{
-		"id": "343",
-		"name": "kz_final_ascension",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=551807622",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "694",
-		"name": "kz_flabbergast",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1770987028",
-		"mapper_name": "CyclO",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "344",
-		"name": "kz_floatingislands",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=738956347",
-		"mapper_name": "lillen",
-		"mapper_steamid64": "76561198077858937"
-	},
-	{
-		"id": "614",
-		"name": "kz_flying_rabbits",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627117444",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "888",
-		"name": "kz_fly_lovers",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2012561467",
-		"mapper_name": "Deppy, persona",
-		"mapper_steamid64": "null, 76561198143205331"
-	},
-	{
-		"id": "345",
-		"name": "kz_foggywarehouse_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387995227",
-		"mapper_name": "pb",
-		"mapper_steamid64": "76561197971221508"
-	},
-	{
-		"id": "253",
-		"name": "kz_forchi",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1860299808",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "346",
-		"name": "kz_forestrace_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=337879628",
-		"mapper_name": "h1m1, old head",
-		"mapper_steamid64": "null, 76561198009989298"
-	},
-	{
-		"id": "695",
-		"name": "kz_forgettable",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1399481815",
-		"mapper_name": "River",
-		"mapper_steamid64": "76561198054436805"
-	},
-	{
-		"id": "547",
-		"name": "kz_forgotten_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1213870327",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "347",
-		"name": "kz_free_ahful",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1167761258",
-		"mapper_name": "Persona",
-		"mapper_steamid64": "76561198143205331"
-	},
-	{
-		"id": "348",
-		"name": "kz_frozen_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066122",
-		"mapper_name": "SoUlFaThEr, SinFuL",
-		"mapper_steamid64": "76561197965266419, 76561197970838363"
-	},
-	{
-		"id": "884",
-		"name": "kz_fury",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224298709",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "652",
-		"name": "kz_fused",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1715598348",
-		"mapper_name": "mjb",
-		"mapper_steamid64": "76561198093921774"
-	},
-	{
-		"id": "349",
-		"name": "kz_futureblock",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=320897168",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "350",
-		"name": "kz_galaxy_go2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066234",
-		"mapper_name": "Woozie"
-	},
-	{
-		"id": "548",
-		"name": "kz_gallus",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=890259285",
-		"mapper_name": "Karo, Diesel",
-		"mapper_steamid64": "76561198059165508, 76561198099241969"
-	},
-	{
-		"id": "913",
-		"name": "kz_gary",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2280509631",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "474",
-		"name": "kz_gc_shark",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2080951339",
-		"mapper_name": "nykaN, GameChaos",
-		"mapper_steamid64": "76561198014491259, 76561198165203332"
-	},
-	{
-		"id": "643",
-		"name": "kz_gemischte_gefuehlslagen",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1280314788",
-		"mapper_name": "Heinzelboss",
-		"mapper_steamid64": "76561198155043164"
-	},
-	{
-		"id": "761",
-		"name": "kz_generic",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2047349909",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "351",
-		"name": "kz_genesis_go2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
-		"mapper_name": "FoF",
-		"mapper_steamid64": "76561197991832101"
-	},
-	{
-		"id": "352",
-		"name": "kz_gfy_blueberry",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=336069751",
-		"mapper_name": "Wally",
-		"mapper_steamid64": "76561197967777192"
-	},
-	{
-		"id": "353",
-		"name": "kz_gfy_c0mb0king",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352458126",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "354",
-		"name": "kz_gfy_devcastle",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399926903",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "355",
-		"name": "kz_gfy_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=438483912",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "356",
-		"name": "kz_gfy_fortroca_finallll",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352459359",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "357",
-		"name": "kz_gfy_limit",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=441312733",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "358",
-		"name": "kz_gfy_strawberry_",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352456857",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "359",
-		"name": "kz_gfy_tech",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=409983599",
-		"mapper_name": "winterNebs",
-		"mapper_steamid64": "76561198040798967"
-	},
-	{
-		"id": "360",
-		"name": "kz_ggurk",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1139544827",
-		"mapper_name": "AFlyingGuru, Flow",
-		"mapper_steamid64": "null, 76561197991750093"
-	},
-	{
-		"id": "617",
-		"name": "kz_ghat",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118013",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "361",
-		"name": "kz_giantbean",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066438",
-		"mapper_name": "KreedZ, SinFuL",
-		"mapper_steamid64": "76561197997103423, 76561197970838363"
-	},
-	{
-		"id": "362",
-		"name": "kz_gigablock_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
-		"mapper_name": "KreedZ, Spherix",
-		"mapper_steamid64": "76561198016516359, null"
-	},
-	{
-		"id": "363",
-		"name": "kz_gitgud_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370366679",
-		"mapper_name": "VypuR",
-		"mapper_steamid64": "76561198027553039"
-	},
-	{
-		"id": "863",
-		"name": "kz_gkd_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240110192",
-		"mapper_name": "Ap",
-		"mapper_steamid64": "76561198331631430"
-	},
-	{
-		"id": "364",
-		"name": "kz_glassesospa_v1",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=212501969",
-		"mapper_name": "Ospa",
-		"mapper_steamid64": "76561197992548863"
-	},
-	{
-		"id": "804",
-		"name": "kz_glide",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1816942862",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "668",
-		"name": "kz_gloom",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1747028736",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "653",
-		"name": "kz_gobbledygook",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1458270387",
-		"mapper_name": "J4BEE, Persona",
-		"mapper_steamid64": "76561198168982111, 76561198143205331"
-	},
-	{
-		"id": "365",
-		"name": "kz_goldenroad",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=227198727",
-		"mapper_name": "Ospa, Al2x",
-		"mapper_steamid64": "76561197992548863, 76561198037766292"
-	},
-	{
-		"id": "696",
-		"name": "kz_goldentabby",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1742520143",
-		"mapper_name": "ShadowBladeXtrm",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "366",
-		"name": "kz_gonbe",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=388981512",
-		"mapper_name": "skitty",
-		"mapper_steamid64": "76561198031452487"
-	},
-	{
-		"id": "367",
-		"name": "kz_goodluck_p",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=315108801",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "638",
-		"name": "kz_goquicklol_v2",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1674495693",
-		"mapper_name": "Mark",
-		"mapper_steamid64": "76561198045869085"
-	},
-	{
-		"id": "368",
-		"name": "kz_grass_hard",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491359087",
-		"mapper_name": "Extremerz",
-		"mapper_steamid64": "76561197965479288"
-	},
-	{
-		"id": "369",
-		"name": "kz_green",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=425209295",
-		"mapper_name": "Piu",
-		"mapper_steamid64": "76561198014009703"
-	},
-	{
-		"id": "370",
-		"name": "kz_gy_agitation",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=444123619",
-		"mapper_name": "Gemayue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "371",
-		"name": "kz_haki_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066638",
-		"mapper_name": "a$ce"
-	},
-	{
-		"id": "499",
-		"name": "kz_halicarnassus_fs",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2080802644",
-		"mapper_name": "Zengal, SinFuL",
-		"mapper_steamid64": "null, 76561197970838363"
-	},
-	{
-		"id": "792",
-		"name": "kz_hammer",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2133476426",
-		"mapper_name": "Makis",
-		"mapper_steamid64": "76561198201492663"
-	},
-	{
-		"id": "717",
-		"name": "kz_haste",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1877331884",
-		"mapper_name": "Dillon",
-		"mapper_steamid64": "76561198120868833"
-	},
-	{
-		"id": "372",
-		"name": "kz_hate",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=875611390",
-		"mapper_name": "Yams",
-		"mapper_steamid64": "76561198348576275"
-	},
-	{
-		"id": "373",
-		"name": "kz_heatvents_mq",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=459351652",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "697",
-		"name": "kz_heaven_od",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1705891534",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "843",
-		"name": "kz_hek",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2175513019",
-		"mapper_name": "Pigeon",
-		"mapper_steamid64": "76561198164405482"
-	},
-	{
-		"id": "374",
-		"name": "kz_hellinashop",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515649978",
-		"mapper_name": "8Ball1, SinFuL",
-		"mapper_steamid64": "null, 76561197970838363"
-	},
-	{
-		"id": "839",
-		"name": "kz_hemochromatosis",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2044616297",
-		"mapper_name": "rov",
-		"mapper_steamid64": "76561198132236283"
-	},
-	{
-		"id": "375",
-		"name": "kz_highland",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=656212893",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "719",
-		"name": "kz_high_socks",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1984921434",
-		"mapper_name": "GameChaos, Samuel",
-		"mapper_steamid64": "76561198165203332, 76561198191875674"
-	},
-	{
-		"id": "586",
-		"name": "kz_hikari_od",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=884785011",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "377",
-		"name": "kz_hillside",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
-		"mapper_name": "s0liD",
-		"mapper_steamid64": "76561197980460370"
-	},
-	{
-		"id": "376",
-		"name": "kz_hitech",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2002217295",
-		"mapper_name": "nykaN",
-		"mapper_steamid64": "76561198014491259"
-	},
-	{
-		"id": "681",
-		"name": "kz_holyspace",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1771753813",
-		"mapper_name": "SodaWater",
-		"mapper_steamid64": "76561198180483758"
-	},
-	{
-		"id": "817",
-		"name": "kz_how2slide_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2166904834",
-		"mapper_name": "Dima",
-		"mapper_steamid64": "76561198198062889"
-	},
-	{
-		"id": "720",
-		"name": "kz_huber",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1702853550",
-		"mapper_name": "Durox",
-		"mapper_steamid64": "76561198072521803"
-	},
-	{
-		"id": "378",
-		"name": "kz_ickkck",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=822776276",
-		"mapper_name": "Rosquilla Guy",
-		"mapper_steamid64": "76561198102575797"
-	},
-	{
-		"id": "379",
-		"name": "kz_illusion_gfix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939577141",
-		"mapper_name": "schm0ftie",
-		"mapper_steamid64": "76561197983561860"
-	},
-	{
-		"id": "380",
-		"name": "kz_iluvprok_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053852",
-		"mapper_name": "Nitekillr",
-		"mapper_steamid64": "76561197987002717"
-	},
-	{
-		"id": "381",
-		"name": "kz_imaginary_final",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=843659203",
-		"mapper_name": "JONY",
-		"mapper_steamid64": "76561198000829729"
-	},
-	{
-		"id": "382",
-		"name": "kz_innit",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1209786787",
-		"mapper_name": "bainz, GameChaos, Danvari",
-		"mapper_steamid64": "76561198183817078, 76561198165203332, 76561198038388449"
-	},
-	{
-		"id": "383",
-		"name": "kz_insomnia_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=594168198",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "384",
-		"name": "kz_inspired",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370117755",
-		"mapper_name": "Kaldren",
-		"mapper_steamid64": "76561197972347749"
-	},
-	{
-		"id": "860",
-		"name": "kz_intercourse!",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207574101",
-		"mapper_name": "stz",
-		"mapper_steamid64": "76561198261992780"
-	},
-	{
-		"id": "385",
-		"name": "kz_internatus",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=551443219",
-		"mapper_name": "Deepus",
-		"mapper_steamid64": "76561197976153012"
-	},
-	{
-		"id": "386",
-		"name": "kz_island",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357579568",
-		"mapper_name": "JumBoO",
-		"mapper_steamid64": "7656119813262611"
-	},
-	{
-		"id": "950",
-		"name": "kz_itz_transcendent",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2373968399",
-		"mapper_name": "iTz",
-		"mapper_steamid64": "76561198104765796"
-	},
-	{
-		"id": "387",
-		"name": "kz_j2s_cupblock_go_fix2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
-		"mapper_name": "s0lid, Spherix",
-		"mapper_steamid64": "76561197980460370, null"
-	},
-	{
-		"id": "388",
-		"name": "kz_j2s_tetris_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
-		"mapper_name": "s0lid, fl0w",
-		"mapper_steamid64": "76561197980460370, 76561197991750093"
-	},
-	{
-		"id": "389",
-		"name": "kz_j2s_westbl0ck",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
-		"mapper_name": "s0lid, fl0w, DanZay",
-		"mapper_steamid64": "76561197980460370, 76561197991750093, 76561197989817982"
-	},
-	{
-		"id": "390",
-		"name": "kz_janpu_final_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357085110",
-		"mapper_name": "Verifyy",
-		"mapper_steamid64": "76561197995535364"
-	},
-	{
-		"id": "391",
-		"name": "kz_jg_ditch",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=367347758",
-		"mapper_name": "ticK!",
-		"mapper_steamid64": "76561198171545305"
-	},
-	{
-		"id": "754",
-		"name": "kz_johndoe",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2015357272",
-		"mapper_name": "Bolo",
-		"mapper_steamid64": "76561198297512910"
-	},
-	{
-		"id": "392",
-		"name": "kz_jump_n_run",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=629040765",
-		"mapper_name": "Smex",
-		"mapper_steamid64": "76561197961558198"
-	},
-	{
-		"id": "889",
-		"name": "kz_kat_colorblind",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2277557067",
-		"mapper_name": "katz, rush2sk8",
-		"mapper_steamid64": "76561198067576863, 76561198082904691"
-	},
-	{
-		"id": "952",
-		"name": "kz_kiwiexultation",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2415258457",
-		"mapper_name": "Kiwi",
-		"mapper_steamid64": "76561198077353609"
-	},
-	{
-		"id": "844",
-		"name": "kz_kiwitech",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2229046768",
-		"mapper_name": "Kiwi",
-		"mapper_steamid64": "76561198077353609"
-	},
-	{
-		"id": "951",
-		"name": "kz_kiwiterror",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2413286682",
-		"mapper_name": "Kiwi",
-		"mapper_steamid64": "76561198077353609"
-	},
-	{
-		"id": "932",
-		"name": "kz_kiwi_cod",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2256093157",
-		"mapper_name": "Kiwi, CoD",
-		"mapper_steamid64": "76561198077353609, 76561198846255522"
-	},
-	{
-		"id": "800",
-		"name": "kz_kohze_sucks",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2130097882",
-		"mapper_name": "Krushed",
-		"mapper_steamid64": "76561197966948458"
-	},
-	{
-		"id": "394",
-		"name": "kz_kzinga_fixed",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=455178914",
-		"mapper_name": "finckelton",
-		"mapper_steamid64": "76561198039388458"
-	},
-	{
-		"id": "762",
-		"name": "kz_kzra_bars",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1901874741",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "763",
-		"name": "kz_kzra_cliffy",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1912922798",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "771",
-		"name": "kz_kzra_hohum",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1877338856",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "682",
-		"name": "kz_kzra_morath",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1761949860",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "793",
-		"name": "kz_kzra_oddland",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2105252723",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "669",
-		"name": "kz_kzra_shortclimb_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753701773",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "699",
-		"name": "kz_kzra_skaxis",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1846345249",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "700",
-		"name": "kz_kzra_slidely",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1816052873",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "887",
-		"name": "kz_kzra_slidepuf",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1824161798",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "851",
-		"name": "kz_kzra_stoneishbhop",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207370784",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "701",
-		"name": "kz_kzra_voovblock",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1795477339",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "685",
-		"name": "kz_kzra_whitesquare",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1793270481",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "772",
-		"name": "kz_kzro_brickstgrass_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2235348857",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "866",
-		"name": "kz_kzro_bronea",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2237646194",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "808",
-		"name": "kz_kzro_gohome",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2117028264",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "867",
-		"name": "kz_kzro_hardvalley",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215405289",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "786",
-		"name": "kz_kzro_mountainbhop",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2118958853",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "906",
-		"name": "kz_kzro_mountainsein",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207874525",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "896",
-		"name": "kz_kzro_mountainsnow",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2230533130",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "883",
-		"name": "kz_kzro_slidesmear",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2239093087",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "845",
-		"name": "kz_kzro_sunmountainset",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2222540470",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "395",
-		"name": "kz_kzse_aztectemple",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=302894093",
-		"mapper_name": "Sinful",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "791",
-		"name": "kz_ladderall",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2124189658",
-		"mapper_name": "Cou",
-		"mapper_steamid64": "76561198007928944"
-	},
-	{
-		"id": "833",
-		"name": "kz_ladderdespair",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2191784508",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "755",
-		"name": "kz_ladderhell_fix",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2034623068",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "396",
-		"name": "kz_lavablock_global",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406054554",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "900",
-		"name": "kz_layercake",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2255773578",
-		"mapper_name": "Downie2K",
-		"mapper_steamid64": "76561197981037626"
-	},
-	{
-		"id": "788",
-		"name": "kz_lazy",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2105506029",
-		"mapper_name": "Michael, Haakz",
-		"mapper_steamid64": "76561198004229810, 76561197990350366"
-	},
-	{
-		"id": "397",
-		"name": "kz_lego",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=351298054",
-		"mapper_name": "DutchSnowman",
-		"mapper_steamid64": "76561198027507070"
-	},
-	{
-		"id": "398",
-		"name": "kz_lego_two_redux_v3",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515550870",
-		"mapper_name": "DutchSnowman",
-		"mapper_steamid64": "76561198027507070"
-	},
-	{
-		"id": "399",
-		"name": "kz_levels",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=635973918",
-		"mapper_name": "Jurkelis",
-		"mapper_steamid64": "76561198071655291"
-	},
-	{
-		"id": "400",
-		"name": "kz_life_final",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=683576131",
-		"mapper_name": "Chaosangel",
-		"mapper_steamid64": "76561198078333036"
-	},
-	{
-		"id": "721",
-		"name": "kz_lionheart",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1805200433",
-		"mapper_name": "iBUYFL0WER Birgit, nutsdoodle",
-		"mapper_steamid64": "76561198078014747, 76561198150143219"
-	},
-	{
-		"id": "819",
-		"name": "kz_list_gnida_v2",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=630032870",
-		"mapper_name": "DeadRote",
-		"mapper_steamid64": "76561198034507626"
-	},
-	{
-		"id": "401",
-		"name": "kz_littlerock_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156067138",
-		"mapper_name": "Surion"
-	},
-	{
-		"id": "917",
-		"name": "kz_loathe",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1961922598",
-		"mapper_name": "JJ",
-		"mapper_steamid64": "76561198167125526"
-	},
-	{
-		"id": "842",
-		"name": "kz_longjumps_easy",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
-		"mapper_name": "ExtremerZ",
-		"mapper_steamid64": "76561197965479288"
-	},
-	{
-		"id": "604",
-		"name": "kz_longjumps_space",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=637925784",
-		"mapper_name": "JONY, CyclO",
-		"mapper_steamid64": "76561198000829729, 76561198024466262"
-	},
-	{
-		"id": "876",
-		"name": "kz_lookout",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2245294640",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "644",
-		"name": "kz_lost_marketplace_gfix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939577604",
-		"mapper_name": "JONY, Rosquilla Guy",
-		"mapper_steamid64": "76561198000829729, 76561198102575797"
-	},
-	{
-		"id": "933",
-		"name": "kz_lovely",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2227118054",
-		"mapper_name": "makis",
-		"mapper_steamid64": "76561198201492663"
-	},
-	{
-		"id": "403",
-		"name": "kz_lume",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=717341154",
-		"mapper_name": "VVoodchip",
-		"mapper_steamid64": "76561198061948302"
-	},
-	{
-		"id": "404",
-		"name": "kz_luonto",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1102578759",
-		"mapper_name": "sBlisss, GameChaos",
-		"mapper_steamid64": "null, 76561198165203332"
-	},
-	{
-		"id": "938",
-		"name": "kz_luv_less",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2350173887",
-		"mapper_name": "J3wDice",
-		"mapper_steamid64": "76561198208729343"
-	},
-	{
-		"id": "405",
-		"name": "kz_mac",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=336084898",
-		"mapper_name": "mac",
-		"mapper_steamid64": "76561198056335207"
-	},
-	{
-		"id": "743",
-		"name": "kz_machinery",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1921655838",
-		"mapper_name": "iBUYFL0WER Birgit",
-		"mapper_steamid64": "76561198078014747"
-	},
-	{
-		"id": "406",
-		"name": "kz_magus",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=401088222",
-		"mapper_name": "Doveen",
-		"mapper_steamid64": "76561198033299991"
-	},
-	{
-		"id": "756",
-		"name": "kz_malignom_short",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1962044626",
-		"mapper_name": "jens",
-		"mapper_steamid64": "76561198110357840"
-	},
-	{
-		"id": "942",
-		"name": "kz_mandelbrot",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259048305",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "407",
-		"name": "kz_man_everest_go_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1098716930",
-		"mapper_name": "Kreedz, Spherix, GnagarN",
-		"mapper_steamid64": "76561197997103423, null, 76561198009902429"
-	},
-	{
-		"id": "408",
-		"name": "kz_marblewalls_fixed",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=391298485",
-		"mapper_name": "Aaron"
-	},
-	{
-		"id": "587",
-		"name": "kz_matilda_np",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1442293882",
-		"mapper_name": "Matilda",
-		"mapper_steamid64": "76561197999312081"
-	},
-	{
-		"id": "670",
-		"name": "kz_meander",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1657680583",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "410",
-		"name": "kz_megabhop_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667953480",
-		"mapper_name": "N1ghtFoX, Chuli"
-	},
-	{
-		"id": "411",
-		"name": "kz_megalodon",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1184142056",
-		"mapper_name": "nykaN",
-		"mapper_steamid64": "76561198014491259"
-	},
-	{
-		"id": "868",
-		"name": "kz_memento",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2226685570",
-		"mapper_name": "Downie2K",
-		"mapper_steamid64": "76561197981037626"
-	},
-	{
-		"id": "654",
-		"name": "kz_mescaline_f",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1704411752",
-		"mapper_name": "mark",
-		"mapper_steamid64": "76561198045869085"
-	},
-	{
-		"id": "412",
-		"name": "kz_metalrun_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406054781",
-		"mapper_name": "Witchhowl",
-		"mapper_steamid64": "76561198027343851"
-	},
-	{
-		"id": "903",
-		"name": "kz_micropenis",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2274722735",
-		"mapper_name": "Cou ",
-		"mapper_steamid64": "76561198007928944"
-	},
-	{
-		"id": "905",
-		"name": "kz_microwave",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259353310",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "824",
-		"name": "kz_mieszaneuczucia",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2168009794",
-		"mapper_name": "nutsdoodle",
-		"mapper_steamid64": "76561198150143219"
-	},
-	{
-		"id": "413",
-		"name": "kz_mike_v4",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352438024",
-		"mapper_name": "MikeChas",
-		"mapper_steamid64": "76561198033854242"
-	},
-	{
-		"id": "773",
-		"name": "kz_milehigh",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2081487108",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "414",
-		"name": "kz_minimalism",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=784686492",
-		"mapper_name": "badges, ρ",
-		"mapper_steamid64": "76561197983438223, 76561198002830622"
-	},
-	{
-		"id": "605",
-		"name": "kz_minimal_combo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688173479",
-		"mapper_name": "UNKNOWN:(",
-		"mapper_steamid64": "76561198140867695"
-	},
-	{
-		"id": "415",
-		"name": "kz_minimountain_f",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1819270715",
-		"mapper_name": "finckelton",
-		"mapper_steamid64": "76561198039388458"
-	},
-	{
-		"id": "588",
-		"name": "kz_modernvomit",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1387010348",
-		"mapper_name": "evanstep",
-		"mapper_steamid64": "76561198067339661"
-	},
-	{
-		"id": "416",
-		"name": "kz_module",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=531121171",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "417",
-		"name": "kz_moonlight",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=653958895",
-		"mapper_name": "jurkelis",
-		"mapper_steamid64": "76561198071655291"
-	},
-	{
-		"id": "625",
-		"name": "kz_moorerutan",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1538928192",
-		"mapper_name": "Rumme",
-		"mapper_steamid64": "76561198112936613"
-	},
-	{
-		"id": "418",
-		"name": "kz_morebricks_msq",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=624692501",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "571",
-		"name": "kz_morestairs_msq",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1370543054",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "807",
-		"name": "kz_motivated",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=504145143",
-		"mapper_name": "Drinka",
-		"mapper_steamid64": "76561198100929785"
-	},
-	{
-		"id": "419",
-		"name": "kz_msp_comatose",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418089472",
-		"mapper_name": "Pebi, masque, skitty",
-		"mapper_steamid64": "76561198077530872, 76561197979436335, 76561198031452487"
-	},
-	{
-		"id": "875",
-		"name": "kz_mushrruption_v8",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2280643029",
-		"mapper_name": "Sehk",
-		"mapper_steamid64": "76561198037724970"
-	},
-	{
-		"id": "744",
-		"name": "kz_mz",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1988044539",
-		"mapper_name": "Zach47, nykaN",
-		"mapper_steamid64": "76561197983014207, 76561198014491259"
-	},
-	{
-		"id": "784",
-		"name": "kz_nassau",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2096632231",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "420",
-		"name": "kz_natureblock_scte",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2111399696",
-		"mapper_name": "Chichin, Pr3da",
-		"mapper_steamid64": "76561197991555455, 76561198021246024"
-	},
-	{
-		"id": "421",
-		"name": "kz_nature_csgo",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080089",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "904",
-		"name": "kz_nb_final",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2246885072",
-		"mapper_name": "Da0lang",
-		"mapper_steamid64": "76561198814294487"
-	},
-	{
-		"id": "947",
-		"name": "kz_neoncity_z",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2260637520",
-		"mapper_name": "_Z",
-		"mapper_steamid64": "76561198365448333"
-	},
-	{
-		"id": "422",
-		"name": "kz_neon_portal",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=427001332",
-		"mapper_name": "TherapySession",
-		"mapper_steamid64": "76561198012265008"
-	},
-	{
-		"id": "802",
-		"name": "kz_nieh",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2128027875",
-		"mapper_name": "S1lic",
-		"mapper_steamid64": "76561198874435443"
-	},
-	{
-		"id": "810",
-		"name": "kz_nightcastle",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2143021601",
-		"mapper_name": "Petter",
-		"mapper_steamid64": "76561198416084167"
-	},
-	{
-		"id": "423",
-		"name": "kz_nightfall",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2073457452",
-		"mapper_name": "Pebi, Danvari",
-		"mapper_steamid64": "76561198077530872, 76561198038388449"
-	},
-	{
-		"id": "424",
-		"name": "kz_nightmare_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=386548794",
-		"mapper_name": "m-tet"
-	},
-	{
-		"id": "698",
-		"name": "kz_nix_od",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1773124335",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "809",
-		"name": "kz_noobfort",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2128202621",
-		"mapper_name": "Lux",
-		"mapper_steamid64": "76561198055771460"
-	},
-	{
-		"id": "940",
-		"name": "kz_northkorean_censorship",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2382813554",
-		"mapper_name": "rov",
-		"mapper_steamid64": "76561198132236283"
-	},
-	{
-		"id": "425",
-		"name": "kz_nyc_v1",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
-		"mapper_name": "Vypur",
-		"mapper_steamid64": "76561198027553039"
-	},
-	{
-		"id": "606",
-		"name": "kz_nymph",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
-		"mapper_name": "Cyclo",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "426",
-		"name": "kz_oasis",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=650371940",
-		"mapper_name": "Pebi",
-		"mapper_steamid64": "76561198077530872"
-	},
-	{
-		"id": "427",
-		"name": "kz_obsidian",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418449564",
-		"mapper_name": "SinFuL",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "723",
-		"name": "kz_okaychamp",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1881193335",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "428",
-		"name": "kz_oldstuff",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491404667",
-		"mapper_name": "DannyE",
-		"mapper_steamid64": "76561198178232629"
-	},
-	{
-		"id": "572",
-		"name": "kz_oloramasa",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1282978596",
-		"mapper_name": "Alves",
-		"mapper_steamid64": "76561198063573203"
-	},
-	{
-		"id": "429",
-		"name": "kz_olympus",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=171110248",
-		"mapper_name": "KingGambit",
-		"mapper_steamid64": "76561198023829871"
-	},
-	{
-		"id": "430",
-		"name": "kz_ominous2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=782868988",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "655",
-		"name": "kz_openspace",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1685172182",
-		"mapper_name": "Lazovsky",
-		"mapper_steamid64": "76561198003859123"
-	},
-	{
-		"id": "431",
-		"name": "kz_orangejuice_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=813837226",
-		"mapper_name": "masque, DanZay",
-		"mapper_steamid64": "76561197979436335, 76561197989817982"
-	},
-	{
-		"id": "432",
-		"name": "kz_orbolution_v2",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=644224500",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "795",
-		"name": "kz_otakuroom",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2106385628",
-		"mapper_name": "GemaYue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "433",
-		"name": "kz_overgrowth",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1092513702",
-		"mapper_name": "stz",
-		"mapper_steamid64": "76561198261992780"
-	},
-	{
-		"id": "626",
-		"name": "kz_overjoyed",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1465826915",
-		"mapper_name": "Gamzky",
-		"mapper_steamid64": "76561198262673963"
-	},
-	{
-		"id": "829",
-		"name": "kz_owtetad",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2190664967",
-		"mapper_name": "Krushed",
-		"mapper_steamid64": "76561197966948458"
-	},
-	{
-		"id": "724",
-		"name": "kz_p1",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1684028086",
-		"mapper_name": "JONY",
-		"mapper_steamid64": "76561198000829729"
-	},
-	{
-		"id": "676",
-		"name": "kz_paintball_tv_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1717536029",
-		"mapper_name": "pb, victoria248",
-		"mapper_steamid64": "76561197971221508, 76561198026839022"
-	},
-	{
-		"id": "774",
-		"name": "kz_pamxul_wip",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2085124881",
-		"mapper_name": "Lux",
-		"mapper_steamid64": "76561198055771460"
-	},
-	{
-		"id": "434",
-		"name": "kz_pantheism_p02",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519500089",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "435",
-		"name": "kz_paradise",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=636580309",
-		"mapper_name": "pr3da",
-		"mapper_steamid64": "76561198021246024"
-	},
-	{
-		"id": "436",
-		"name": "kz_peak_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419054557",
-		"mapper_name": "PHQ",
-		"mapper_steamid64": "76561197981825703"
-	},
-	{
-		"id": "934",
-		"name": "kz_pendulum",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1937590263",
-		"mapper_name": "JJ",
-		"mapper_steamid64": "76561198167125526"
-	},
-	{
-		"id": "931",
-		"name": "kz_perfunctory",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2253427267",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "437",
-		"name": "kz_phamous",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=404322417",
-		"mapper_name": "Phinx",
-		"mapper_steamid64": "76561198023207107"
-	},
-	{
-		"id": "438",
-		"name": "kz_pharaoh_csgo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=377402121",
-		"mapper_name": "Daniel_Lyness"
-	},
-	{
-		"id": "859",
-		"name": "kz_pharos_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2274441302",
-		"mapper_name": "Crixxzi",
-		"mapper_steamid64": "76561198046307458"
-	},
-	{
-		"id": "439",
-		"name": "kz_phaztec",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399418936",
-		"mapper_name": "Phinx",
-		"mapper_steamid64": "76561198023207107"
-	},
-	{
-		"id": "440",
-		"name": "kz_pianoclimb_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=230274161",
-		"mapper_name": "DyleT2"
-	},
-	{
-		"id": "441",
-		"name": "kz_pineforest_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=778556068",
-		"mapper_name": "Lillen",
-		"mapper_steamid64": "76561198077858937"
-	},
-	{
-		"id": "442",
-		"name": "kz_piranha",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1185869594",
-		"mapper_name": "GameChaos",
-		"mapper_steamid64": "76561198165203332"
-	},
-	{
-		"id": "443",
-		"name": "kz_pixelrun_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=782827606",
-		"mapper_name": "TheWhaleMan",
-		"mapper_steamid64": "76561198064508818"
-	},
-	{
-		"id": "444",
-		"name": "kz_plains",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=747076334",
-		"mapper_name": "Shire",
-		"mapper_steamid64": "76561198104341799"
-	},
-	{
-		"id": "445",
-		"name": "kz_pollution",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=633854360",
-		"mapper_name": "pr3da",
-		"mapper_steamid64": "76561198021246024"
-	},
-	{
-		"id": "656",
-		"name": "kz_porridge",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1533494110",
-		"mapper_name": "Diesel",
-		"mapper_steamid64": "76561198099241969"
-	},
-	{
-		"id": "806",
-		"name": "kz_portal_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2208043488",
-		"mapper_name": "epic",
-		"mapper_steamid64": "76561198028317188"
-	},
-	{
-		"id": "607",
-		"name": "kz_prekeeper",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1535314044",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "446",
-		"name": "kz_prima",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=896453952",
-		"mapper_name": "Cobrex",
-		"mapper_steamid64": "76561198060634245"
-	},
-	{
-		"id": "447",
-		"name": "kz_prismus",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080437",
-		"mapper_name": "Deepus",
-		"mapper_steamid64": "76561197976153012"
-	},
-	{
-		"id": "946",
-		"name": "kz_procrastination_f",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2370566385",
-		"mapper_name": "lenny",
-		"mapper_steamid64": "76561198145963095"
-	},
-	{
-		"id": "956",
-		"name": "kz_progressive",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2421910892",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "448",
-		"name": "kz_project",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=656536301",
-		"mapper_name": "Isk",
-		"mapper_steamid64": "76561198195095059"
-	},
-	{
-		"id": "782",
-		"name": "kz_prolific",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2091137824",
-		"mapper_name": "jord",
-		"mapper_steamid64": "76561198066952826"
-	},
-	{
-		"id": "608",
-		"name": "kz_prototype",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=520364028",
-		"mapper_name": "Smex",
-		"mapper_steamid64": "76561197961558198"
-	},
-	{
-		"id": "910",
-		"name": "kz_psychosomatic",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2422388657",
-		"mapper_name": "Plastyc, Raunox",
-		"mapper_steamid64": "76561199024218227, 76561198254175551"
-	},
-	{
-		"id": "790",
-		"name": "kz_psyk",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030706198",
-		"mapper_name": "G O A",
-		"mapper_steamid64": "76561197990887735"
-	},
-	{
-		"id": "449",
-		"name": "kz_psytime_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=623887144",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "745",
-		"name": "kz_purgatory",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1943903062",
-		"mapper_name": "Amber, htc, Rebmaa",
-		"mapper_steamid64": "null, null, 76561197970776455 "
-	},
-	{
-		"id": "450",
-		"name": "kz_quadrablock",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068013",
-		"mapper_name": "Pix"
-	},
-	{
-		"id": "451",
-		"name": "kz_quadrant_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1369715256",
-		"mapper_name": "River",
-		"mapper_steamid64": "76561198054436805"
-	},
-	{
-		"id": "452",
-		"name": "kz_quick7_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=562956061",
-		"mapper_name": "MurrayAU",
-		"mapper_steamid64": "76561198019551123"
-	},
-	{
-		"id": "620",
-		"name": "kz_quicksand",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1579335691",
-		"mapper_name": "Sisms(?)",
-		"mapper_steamid64": "76561198166999579"
-	},
-	{
-		"id": "453",
-		"name": "kz_quickshot",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=437195052",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "454",
-		"name": "kz_quixotic",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=581076797",
-		"mapper_name": "Matilda",
-		"mapper_steamid64": "76561197999312081"
-	},
-	{
-		"id": "455",
-		"name": "kz_railings",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=301219724",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "456",
-		"name": "kz_rainrun_kn_f",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509126081",
-		"mapper_name": "Knove",
-		"mapper_steamid64": "76561198109227174"
-	},
-	{
-		"id": "457",
-		"name": "kz_rcn_impermanence",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1235824121",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "458",
-		"name": "kz_rcn_optimisery",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1228153185",
-		"mapper_name": "archon",
-		"mapper_steamid64": "76561198034601835"
-	},
-	{
-		"id": "459",
-		"name": "kz_reach_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=421596934",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "813",
-		"name": "kz_rectangle",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2127477792",
-		"mapper_name": "Michael",
-		"mapper_steamid64": "76561198004229810"
-	},
-	{
-		"id": "460",
-		"name": "kz_redemption_csgo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=269756340",
-		"mapper_name": "Tipii, fl0w",
-		"mapper_steamid64": "null, 76561197991750093"
-	},
-	{
-		"id": "461",
-		"name": "kz_redline",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
-		"mapper_name": "ExtremerZ",
-		"mapper_steamid64": "76561197965479288"
-	},
-	{
-		"id": "764",
-		"name": "kz_refract",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2054929131",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "901",
-		"name": "kz_refuge",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2260756501",
-		"mapper_name": "nykaN",
-		"mapper_steamid64": "76561198014491259"
-	},
-	{
-		"id": "462",
-		"name": "kz_remedy_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=458847658",
-		"mapper_name": "Piu",
-		"mapper_steamid64": "76561198014009703"
-	},
-	{
-		"id": "688",
-		"name": "kz_research",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1233676255",
-		"mapper_name": "Fafnir",
-		"mapper_steamid64": "76561198072210646"
-	},
-	{
-		"id": "463",
-		"name": "kz_retribution_v2_final",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535037159",
-		"mapper_name": "Flux",
-		"mapper_steamid64": "76561198040691989"
-	},
-	{
-		"id": "464",
-		"name": "kz_return",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=610279618",
-		"mapper_name": "DanZay",
-		"mapper_steamid64": "76561197989817982"
-	},
-	{
-		"id": "899",
-		"name": "kz_reverse",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2261076218",
-		"mapper_name": "Temmie, Da0lang",
-		"mapper_steamid64": "76561198137502865, 76561198814294487"
-	},
-	{
-		"id": "628",
-		"name": "kz_rise",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=661509726",
-		"mapper_name": "schm0ftie",
-		"mapper_steamid64": "76561197983561860"
-	},
-	{
-		"id": "465",
-		"name": "kz_rockclimb",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=294354248",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "466",
-		"name": "kz_rockjungle_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=706798826",
-		"mapper_name": "GWB",
-		"mapper_steamid64": "76561198010817168"
-	},
-	{
-		"id": "467",
-		"name": "kz_rocks_global",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1728344964",
-		"mapper_name": "keyuu",
-		"mapper_steamid64": "76561198003202977"
-	},
-	{
-		"id": "765",
-		"name": "kz_roman",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2071759440",
-		"mapper_name": "Ori",
-		"mapper_steamid64": "76561198157565655"
-	},
-	{
-		"id": "874",
-		"name": "kz_rompenutrias_asheglado",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1528890944",
-		"mapper_name": "Shendal",
-		"mapper_steamid64": "76561198225775664"
-	},
-	{
-		"id": "555",
-		"name": "kz_rumzor",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1157701765",
-		"mapper_name": "Rumme",
-		"mapper_steamid64": "76561198112936613"
-	},
-	{
-		"id": "852",
-		"name": "kz_rush2sk8",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2212481749",
-		"mapper_name": "rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "919",
-		"name": "kz_rush2suck",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2346899830",
-		"mapper_name": "Krushed, stz, nopey",
-		"mapper_steamid64": "76561197966948458, 76561198261992780, 76561198401447544"
-	},
-	{
-		"id": "468",
-		"name": "kz_sanctuary",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387095066",
-		"mapper_name": "Ace"
-	},
-	{
-		"id": "469",
-		"name": "kz_sandstone_mq",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=318255698",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "470",
-		"name": "kz_sandstorm_ez",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399829430",
-		"mapper_name": "DropInMilk",
-		"mapper_steamid64": "76561198033385282"
-	},
-	{
-		"id": "471",
-		"name": "kz_sandyhill_hoc",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068273",
-		"mapper_name": "SinFuL",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "886",
-		"name": "kz_scum",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2262738254",
-		"mapper_name": "dillon",
-		"mapper_steamid64": "76561198120868833"
-	},
-	{
-		"id": "472",
-		"name": "kz_sendhelp_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=414276208",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "473",
-		"name": "kz_serenity",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=564068433",
-		"mapper_name": "UnderhellCS",
-		"mapper_steamid64": "76561198071769233"
-	},
-	{
-		"id": "877",
-		"name": "kz_shaft_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228832434",
-		"mapper_name": "Beikenost",
-		"mapper_steamid64": "76561198117002699"
-	},
-	{
-		"id": "671",
-		"name": "kz_shell",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1640657838",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "766",
-		"name": "kz_shortcut_tx",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2059971679",
-		"mapper_name": "Elem",
-		"mapper_steamid64": "76561199023877609"
-	},
-	{
-		"id": "475",
-		"name": "kz_signs_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=570362293",
-		"mapper_name": "Guta",
-		"mapper_steamid64": "76561198000799482"
-	},
-	{
-		"id": "726",
-		"name": "kz_simplejourney",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1842969271",
-		"mapper_name": "ρ",
-		"mapper_steamid64": "76561198002830622"
-	},
-	{
-		"id": "725",
-		"name": "kz_simple_sp",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1995891136",
-		"mapper_name": "saicho91",
-		"mapper_steamid64": "76561197995141366"
-	},
-	{
-		"id": "476",
-		"name": "kz_simplicity_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=596881274",
-		"mapper_name": "Netcode",
-		"mapper_steamid64": "76561198083399596"
-	},
-	{
-		"id": "836",
-		"name": "kz_skybridge",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2170006392",
-		"mapper_name": "Aquilla",
-		"mapper_steamid64": "76561198337861414"
-	},
-	{
-		"id": "477",
-		"name": "kz_skyhotel",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=508852626",
-		"mapper_name": "Flux",
-		"mapper_steamid64": "76561198040691989"
-	},
-	{
-		"id": "556",
-		"name": "kz_sky_lake",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1298788457",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "479",
-		"name": "kz_slate",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=871544753",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "702",
-		"name": "kz_slidebober",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1825259311",
-		"mapper_name": "Slyph"
-	},
-	{
-		"id": "746",
-		"name": "kz_slidemap_ez_v2_rmk_final",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2421819231",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "949",
-		"name": "kz_slide_concrete",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2356803567",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "775",
-		"name": "kz_slide_deee",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2016401059",
-		"mapper_name": "Dima",
-		"mapper_steamid64": "76561198198062889"
-	},
-	{
-		"id": "632",
-		"name": "kz_slide_dydanhomon",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1586833508",
-		"mapper_name": "dydka",
-		"mapper_steamid64": "76561198010747369"
-	},
-	{
-		"id": "797",
-		"name": "kz_slide_kissa",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2081916777",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "757",
-		"name": "kz_slide_koira",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2010190400",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "909",
-		"name": "kz_slide_pallokala",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2288332530",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "890",
-		"name": "kz_slide_pisauva",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2251257791",
-		"mapper_name": "Shendal",
-		"mapper_steamid64": "76561198225775664"
-	},
-	{
-		"id": "703",
-		"name": "kz_slide_purple_x",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1842176999",
-		"mapper_name": "Kirman, PreFect"
-	},
-	{
-		"id": "945",
-		"name": "kz_slide_rawr_xdeee",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2190416060",
-		"mapper_name": "Dima",
-		"mapper_steamid64": "76561198198062889"
-	},
-	{
-		"id": "727",
-		"name": "kz_slide_rovod",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2418190102",
-		"mapper_name": "rov, Overdose",
-		"mapper_steamid64": "76561198132236283, 76561198142809343"
-	},
-	{
-		"id": "609",
-		"name": "kz_slide_svn_extreme",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1545821165",
-		"mapper_name": "SilverNinja"
-	},
-	{
-		"id": "704",
-		"name": "kz_slide_svn_temple",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1866612534",
-		"mapper_name": "SilverNinja"
-	},
-	{
-		"id": "821",
-		"name": "kz_slide_vaahtera",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2184236748",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "818",
-		"name": "kz_slowrun_global_fix",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1355920261",
-		"mapper_name": "cnc3ep1",
-		"mapper_steamid64": "76561198143741877"
-	},
-	{
-		"id": "672",
-		"name": "kz_slumpfrageous",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1741709684",
-		"mapper_name": "victoria248",
-		"mapper_steamid64": "76561198026839022"
-	},
-	{
-		"id": "789",
-		"name": "kz_smallcastle",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2025955407",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "573",
-		"name": "kz_smallmap",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1339159026",
-		"mapper_name": "Samuel",
-		"mapper_steamid64": "76561198191875674"
-	},
-	{
-		"id": "480",
-		"name": "kz_snowman_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=337956674",
-		"mapper_name": "DutchSnowman",
-		"mapper_steamid64": "76561198027507070"
-	},
-	{
-		"id": "481",
-		"name": "kz_solidarity_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580922647",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "955",
-		"name": "kz_sonder",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2385596806",
-		"mapper_name": "dillon",
-		"mapper_steamid64": "76561198120868833"
-	},
-	{
-		"id": "853",
-		"name": "kz_sp1_bloodyljs",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224266412",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "880",
-		"name": "kz_sp1_candles",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2243496277",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "912",
-		"name": "kz_sp1_castaway",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2283294555",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "935",
-		"name": "kz_sp1_hallwaybhop",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2305555371",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "854",
-		"name": "kz_sp1_hiragana",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2210394074",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "948",
-		"name": "kz_sp1_katakana",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381711985",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "927",
-		"name": "kz_sp1_perf2win",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2322149205",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "861",
-		"name": "kz_spaceladders_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2229077733",
-		"mapper_name": "Cybur",
-		"mapper_steamid64": "76561198062384407"
-	},
-	{
-		"id": "557",
-		"name": "kz_spacemario_h",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685184665",
-		"mapper_name": "Eightb0",
-		"mapper_steamid64": "76561198010762038"
-	},
-	{
-		"id": "482",
-		"name": "kz_spacus",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=522846216",
-		"mapper_name": "Deepus, Hawk",
-		"mapper_steamid64": "76561197976153012, 76561198218057127"
-	},
-	{
-		"id": "846",
-		"name": "kz_spire",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2205432051",
-		"mapper_name": "RZL, Fnugz",
-		"mapper_steamid64": "76561197985774978, 76561198012891563"
-	},
-	{
-		"id": "483",
-		"name": "kz_spiritblockv2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068550",
-		"mapper_name": "jYue, SoUlFaThEr",
-		"mapper_steamid64": "null, 76561197965266419"
-	},
-	{
-		"id": "812",
-		"name": "kz_splopkopsc_loverick",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1126798978",
-		"mapper_name": "Steez",
-		"mapper_steamid64": "76561198261992780"
-	},
-	{
-		"id": "484",
-		"name": "kz_spores_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418447771",
-		"mapper_name": "G O A",
-		"mapper_steamid64": "76561197990887735"
-	},
-	{
-		"id": "485",
-		"name": "kz_sqrdsucks",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=870091342",
-		"mapper_name": "Krushed",
-		"mapper_steamid64": "76561197966948458"
-	},
-	{
-		"id": "855",
-		"name": "kz_stepblock",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2221286065",
-		"mapper_name": "Crixxzi",
-		"mapper_steamid64": "76561198046307458"
-	},
-	{
-		"id": "954",
-		"name": "kz_stepup",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2378820376",
-		"mapper_name": "Emzatin",
-		"mapper_steamid64": "76561198393292046"
-	},
-	{
-		"id": "486",
-		"name": "kz_strafehop_fix",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=727970399",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "487",
-		"name": "kz_stranded",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=881021394",
-		"mapper_name": "nykaN, coach",
-		"mapper_steamid64": "76561198014491259, 76561197969061501"
-	},
-	{
-		"id": "488",
-		"name": "kz_streetblock_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
-		"mapper_name": "s0lid",
-		"mapper_steamid64": "76561197980460370"
-	},
-	{
-		"id": "856",
-		"name": "kz_structures",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=613750240",
-		"mapper_name": "colony",
-		"mapper_steamid64": "76561198012716104"
-	},
-	{
-		"id": "489",
-		"name": "kz_strun_mq",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=522194087",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "490",
-		"name": "kz_stuff_final",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=397542914",
-		"mapper_name": "Pebi",
-		"mapper_steamid64": "76561198077530872"
-	},
-	{
-		"id": "491",
-		"name": "kz_sukblock_v2_fixed",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=511719435",
-		"mapper_name": "Suck' TearZ"
-	},
-	{
-		"id": "492",
-		"name": "kz_summercliff2_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
-		"mapper_name": "s0liD",
-		"mapper_steamid64": "76561197980460370"
-	},
-	{
-		"id": "776",
-		"name": "kz_suomi",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030976502",
-		"mapper_name": "tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "915",
-		"name": "kz_superstructure",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2252104070",
-		"mapper_name": "_max",
-		"mapper_steamid64": "76561198083065598"
-	},
-	{
-		"id": "944",
-		"name": "kz_surf_ace",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2366218120",
-		"mapper_name": "Dima, Juxtapo",
-		"mapper_steamid64": "76561198198062889, 76561197982874432"
-	},
-	{
-		"id": "705",
-		"name": "kz_surf_blue",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1777661554",
-		"mapper_name": "CyclO",
-		"mapper_steamid64": "76561198024466262"
-	},
-	{
-		"id": "494",
-		"name": "kz_surf_kim_hana_gl",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=846934364",
-		"mapper_name": "Gull",
-		"mapper_steamid64": "76561198137589262"
-	},
-	{
-		"id": "495",
-		"name": "kz_swamped_v3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=737262158",
-		"mapper_name": "Orbit",
-		"mapper_steamid64": "76561198057269402"
-	},
-	{
-		"id": "496",
-		"name": "kz_symbiosis_final",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=407752167",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "835",
-		"name": "kz_symmetry",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2169425331",
-		"mapper_name": "Lameskydiver",
-		"mapper_steamid64": "76561198082880577"
-	},
-	{
-		"id": "219",
-		"name": "kz_synergy_ez",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030361679",
-		"mapper_name": "pLANE, fl0w",
-		"mapper_steamid64": "76561197969425557, 76561197991750093"
-	},
-	{
-		"id": "220",
-		"name": "kz_synergy_x",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030360282",
-		"mapper_name": "pLANE, fl0w",
-		"mapper_steamid64": "76561197969425557, 76561197991750093"
-	},
-	{
-		"id": "497",
-		"name": "kz_synthesis_v2",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=524273901",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "498",
-		"name": "kz_sz_goldenbean",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279111456",
-		"mapper_name": "SinFuL",
-		"mapper_steamid64": "76561197970838363"
-	},
-	{
-		"id": "500",
-		"name": "kz_talltreeforest_v3",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=353767057",
-		"mapper_name": "Vypur",
-		"mapper_steamid64": "76561198027553039"
-	},
-	{
-		"id": "501",
-		"name": "kz_talmaniac",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=875664112",
-		"mapper_name": "AREDONE, GameChaos",
-		"mapper_steamid64": "76561198082306844, 76561198165203332"
-	},
-	{
-		"id": "857",
-		"name": "kz_technical_difficulties",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215677224",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "637",
-		"name": "kz_techtonic_v2_ldr",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1679345238",
-		"mapper_name": "iBUYFL0WER Birgit",
-		"mapper_steamid64": "76561198078014747"
-	},
-	{
-		"id": "502",
-		"name": "kz_terablock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=269563440",
-		"mapper_name": "SinFul, fl0w",
-		"mapper_steamid64": "null, 76561197991750093"
-	},
-	{
-		"id": "816",
-		"name": "kz_theaquila",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2183036742",
-		"mapper_name": "Aquilla",
-		"mapper_steamid64": "76561198337861414"
-	},
-	{
-		"id": "610",
-		"name": "kz_thinkblock",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1543810415",
-		"mapper_name": "xq, GameChaos",
-		"mapper_steamid64": "76561198094382485, 76561198165203332"
-	},
-	{
-		"id": "748",
-		"name": "kz_thrombosis",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1803151428",
-		"mapper_name": "rov",
-		"mapper_steamid64": "76561198132236283"
-	},
-	{
-		"id": "503",
-		"name": "kz_timescape_zero",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=937263331",
-		"mapper_name": "Blixx",
-		"mapper_steamid64": "76561198017413484"
-	},
-	{
-		"id": "504",
-		"name": "kz_tomb_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1099232235",
-		"mapper_name": "MoHaX_cm"
-	},
-	{
-		"id": "505",
-		"name": "kz_toonadventure_go",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068846",
-		"mapper_name": "PHQ",
-		"mapper_steamid64": "76561197981825703"
-	},
-	{
-		"id": "506",
-		"name": "kz_toonrun_final",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=375234842",
-		"mapper_name": "BigBangQuint"
-	},
-	{
-		"id": "673",
-		"name": "kz_toughluck_fix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1740708159",
-		"mapper_name": "TurboAgent"
-	},
-	{
-		"id": "508",
-		"name": "kz_tour_de_nuke_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406055304",
-		"mapper_name": "bacUp",
-		"mapper_steamid64": "76561197992737822"
-	},
-	{
-		"id": "509",
-		"name": "kz_tradeblock_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352763435",
-		"mapper_name": "Millet"
-	},
-	{
-		"id": "510",
-		"name": "kz_trashsurf",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419954977",
-		"mapper_name": "ticK!",
-		"mapper_steamid64": "76561198171545305"
-	},
-	{
-		"id": "783",
-		"name": "kz_trazodon_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2167786919",
-		"mapper_name": "Zeldox",
-		"mapper_steamid64": "76561197965379945"
-	},
-	{
-		"id": "511",
-		"name": "kz_tribute",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=771511732",
-		"mapper_name": "darksy",
-		"mapper_steamid64": "76561197985961109"
-	},
-	{
-		"id": "512",
-		"name": "kz_tron_global",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406055395"
-	},
-	{
-		"id": "677",
-		"name": "kz_twiivo",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1755261291",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198094382485"
-	},
-	{
-		"id": "493",
-		"name": "kz_twilight_od",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1885058481",
-		"mapper_name": "Overdose",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "787",
-		"name": "kz_twister",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2104121795",
-		"mapper_name": "Fksch",
-		"mapper_steamid64": "76561198142682783"
-	},
-	{
-		"id": "893",
-		"name": "kz_unity_collab",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=864605202",
-		"mapper_name": "G O A, Magical, ρ",
-		"mapper_steamid64": "76561197990887735, 76561197994466910, 76561198002830622"
-	},
-	{
-		"id": "513",
-		"name": "kz_unity_u01",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519498299",
-		"mapper_name": "zPrince",
-		"mapper_steamid64": "76561198047032125"
-	},
-	{
-		"id": "690",
-		"name": "kz_unknownspace",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1738660683",
-		"mapper_name": "mjb",
-		"mapper_steamid64": "76561198093921774"
-	},
-	{
-		"id": "865",
-		"name": "kz_unmake",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2201592299",
-		"mapper_name": "Chichin",
-		"mapper_steamid64": "76561197991555455"
-	},
-	{
-		"id": "878",
-		"name": "kz_variety_fix",
-		"difficulty": "4",
-		"workshop_url": " https://steamcommunity.com/sharedfiles/filedetails/?id=2251584934",
-		"mapper_name": "Emzatin",
-		"mapper_steamid64": "76561198393292046"
-	},
-	{
-		"id": "514",
-		"name": "kz_vci_apprentice",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685276922",
-		"mapper_name": "VCi",
-		"mapper_steamid64": "76561198177716323"
-	},
-	{
-		"id": "515",
-		"name": "kz_verv3_gg",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=568150287",
-		"mapper_name": "Greg",
-		"mapper_steamid64": "76561198029772319"
-	},
-	{
-		"id": "630",
-		"name": "kz_village",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1613996676",
-		"mapper_name": "biql, GameChaos",
-		"mapper_steamid64": "76561198146445979, 76561198165203332"
-	},
-	{
-		"id": "516",
-		"name": "kz_violet_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=603787190",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "674",
-		"name": "kz_vittu_mika_persse",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1735347577",
-		"mapper_name": "victoria248",
-		"mapper_steamid64": "76561198026839022"
-	},
-	{
-		"id": "517",
-		"name": "kz_void",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=789833143",
-		"mapper_name": "finckelton",
-		"mapper_steamid64": "76561198039388458"
-	},
-	{
-		"id": "518",
-		"name": "kz_warehouse",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=288587982",
-		"mapper_name": "Witchhowl",
-		"mapper_steamid64": "76561198027343851"
-	},
-	{
-		"id": "657",
-		"name": "kz_waterhole",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1656359071",
-		"mapper_name": "lazovsky"
-	},
-	{
-		"id": "777",
-		"name": "kz_weebfactory_censored",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2110341385",
-		"mapper_name": "mark",
-		"mapper_steamid64": "76561198045869085"
-	},
-	{
-		"id": "611",
-		"name": "kz_wetbricks",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1341015034",
-		"mapper_name": "Random Eye",
-		"mapper_steamid64": "76561197987069371"
-	},
-	{
-		"id": "519",
-		"name": "kz_whatever_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=439146522",
-		"mapper_name": "GemaYue",
-		"mapper_steamid64": "76561198019909186"
-	},
-	{
-		"id": "678",
-		"name": "kz_why",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1773239409",
-		"mapper_name": "archon, Overdose",
-		"mapper_steamid64": "76561198034601835, 76561198142809343"
-	},
-	{
-		"id": "520",
-		"name": "kz_woodstock_v2",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=620160091",
-		"mapper_name": "pr3da",
-		"mapper_steamid64": "76561198021246024"
-	},
-	{
-		"id": "521",
-		"name": "kz_woodstonegrass_final",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=594369922",
-		"mapper_name": "MurrayAU",
-		"mapper_steamid64": "76561198019551123"
-	},
-	{
-		"id": "522",
-		"name": "kz_woodworld",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=306647639",
-		"mapper_name": "masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "523",
-		"name": "kz_xand",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387908744",
-		"mapper_name": "a$ce"
-	},
-	{
-		"id": "615",
-		"name": "kz_xmas2008",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118382",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "616",
-		"name": "kz_xmas2009",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118842",
-		"mapper_name": "FoF, ρ",
-		"mapper_steamid64": "76561197991832101, 76561198002830622"
-	},
-	{
-		"id": "907",
-		"name": "kz_xmas2020",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224396057",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "524",
-		"name": "kz_xtremeblock_v2",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156069128",
-		"mapper_name": "Chrizzy"
-	},
-	{
-		"id": "574",
-		"name": "kz_yoink",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1308906365",
-		"mapper_name": "bainz, GameChaos",
-		"mapper_steamid64": "76561198183817078, 76561198165203332"
-	},
-	{
-		"id": "822",
-		"name": "kz_zaloopazxc",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1918571009",
-		"mapper_name": "downeel",
-		"mapper_steamid64": "76561198160259346"
-	},
-	{
-		"id": "525",
-		"name": "kz_za_tileblock",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080925",
-		"mapper_name": "Masque",
-		"mapper_steamid64": "76561197979436335"
-	},
-	{
-		"id": "526",
-		"name": "kz_zhop_freestyle",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685863435",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "527",
-		"name": "kz_zhop_function3",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=606199162",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "528",
-		"name": "kz_zhop_son_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580178806",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "529",
-		"name": "kz_ziggurath_final",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=684097443",
-		"mapper_name": "burny",
-		"mapper_steamid64": "76561197989457424"
-	},
-	{
-		"id": "729",
-		"name": "kz_zoomer_fix",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996270299",
-		"mapper_name": "CoD",
-		"mapper_steamid64": "76561198846255522"
-	},
-	{
-		"id": "530",
-		"name": "kz_zxp_final4",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=632673660",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "645",
-		"name": "kz_zxp_interstellar_v2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667954510",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "531",
-		"name": "kz_zxp_undia",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=639874816",
-		"mapper_name": "Zprince",
-		"mapper_steamid64": "76561198151858167"
-	},
-	{
-		"id": "612",
-		"name": "skz_bananaysoda_2",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1200744110",
-		"mapper_name": "Jony",
-		"mapper_steamid64": "76561198000829729"
-	},
-	{
-		"id": "589",
-		"name": "skz_makalaka",
-		"difficulty": "7",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1340859713",
-		"mapper_name": "Gamechaos",
-		"mapper_steamid64": "76561198165203332"
-	},
-	{
-		"id": "869",
-		"name": "skz_map",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2257677246",
-		"mapper_name": "Rush2sk8",
-		"mapper_steamid64": "76561198082904691"
-	},
-	{
-		"id": "640",
-		"name": "skz_odious_v2",
-		"difficulty": "6",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2001125206",
-		"mapper_name": "xq, Danvari",
-		"mapper_steamid64": "76561198094382485, 76561198038388449"
-	},
-	{
-		"id": "558",
-		"name": "skz_sati",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1226660943",
-		"mapper_name": "xq",
-		"mapper_steamid64": "76561198142809343"
-	},
-	{
-		"id": "891",
-		"name": "skz_sequence_shot",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2263251231",
-		"mapper_name": "lenny",
-		"mapper_steamid64": "76561198145963095"
-	},
-	{
-		"id": "633",
-		"name": "vnl_cat",
-		"difficulty": "4",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1594689613",
-		"mapper_name": "Schrødna",
-		"mapper_steamid64": "76561198067192262"
-	},
-	{
-		"id": "837",
-		"name": "vnl_invasion",
-		"difficulty": "5",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2027995295",
-		"mapper_name": "Birgit",
-		"mapper_steamid64": "76561198078014747"
-	},
-	{
-		"id": "841",
-		"name": "vnl_whiterun",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2209883717",
-		"mapper_name": "Spider1",
-		"mapper_steamid64": "76561198042146961"
-	},
-	{
-		"id": "778",
-		"name": "xc_alt_nephilim",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2072370967",
-		"mapper_name": "G O A",
-		"mapper_steamid64": "76561197990887735"
-	},
-	{
-		"id": "858",
-		"name": "xc_cliffjump_fix",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215515724",
-		"mapper_name": "Tatska",
-		"mapper_steamid64": "76561198433558585"
-	},
-	{
-		"id": "596",
-		"name": "xc_dreamland2",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1287723058",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "559",
-		"name": "xc_dtt_nasty_go",
-		"difficulty": "1",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1257230741",
-		"mapper_name": "Dogers, ρ",
-		"mapper_steamid64": "null, 76561198002830622"
-	},
-	{
-		"id": "560",
-		"name": "xc_fox_shrine_japan_fr",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1279693156",
-		"mapper_name": "incAming"
-	},
-	{
-		"id": "532",
-		"name": "xc_karo4",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1193986481",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "533",
-		"name": "xc_lucid_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406056737",
-		"mapper_name": "G O A",
-		"mapper_steamid64": "76561197990887735"
-	},
-	{
-		"id": "534",
-		"name": "xc_minecraft2_global",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419053494",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "535",
-		"name": "xc_minecraft3_global",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406057063",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "758",
-		"name": "xc_minecraft4",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2025541839",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	},
-	{
-		"id": "536",
-		"name": "xc_nephilim",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
-		"mapper_name": "G O A",
-		"mapper_steamid64": "76561197990887735"
-	},
-	{
-		"id": "537",
-		"name": "xc_powerblock_rc1",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156206701",
-		"mapper_name": "RZL",
-		"mapper_steamid64": "76561197985774978"
-	},
-	{
-		"id": "538",
-		"name": "xc_secret_valley_global_fix",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=451014834",
-		"mapper_name": "Sodan Tok"
-	},
-	{
-		"id": "539",
-		"name": "xc_skycastle",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1660023848",
-		"mapper_name": "Bendix, victoria248",
-		"mapper_steamid64": "null, 76561198026839022"
-	},
-	{
-		"id": "540",
-		"name": "xc_supermario_go_gfix",
-		"difficulty": "2",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939578036",
-		"mapper_name": "Disturbed, Iconic"
-	},
-	{
-		"id": "541",
-		"name": "xc_umbrella_global",
-		"difficulty": "3",
-		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419054050",
-		"mapper_name": "ProAqua",
-		"mapper_steamid64": "76561198051496034"
-	}
+[
+   {
+      "id":"200",
+      "name":"bkz_apricity_v3",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1986459033",
+      "mapper_name":"Badges",
+      "mapper_steamid64":"76561197983438223"
+   },
+   {
+      "id":"201",
+      "name":"bkz_blackrockshooter_vzp",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
+      "mapper_name":"Reborn"
+      "mapper_steamid64":"76561197992700411"
+   },
+   {
+      "id":"202",
+      "name":"bkz_bonus_z1",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509297499",
+      "mapper_name":"ZPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"269",
+      "name":"bkz_cakewalk",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1613453363",
+      "mapper_name":"zPrince, GameChaos",
+      "mapper_steamid64":"76561198047032125, 76561198165203332"
+   },
+   {
+      "id":"203",
+      "name":"bkz_cauz_final",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535665232",
+      "mapper_name":"Cau",
+      "mapper_steamid64":"76561198041208499"
+   },
+   {
+      "id":"204",
+      "name":"bkz_cauz_short",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535645053",
+      "mapper_name":"Cau",
+      "mapper_steamid64":"76561198041208499"
+   },
+   {
+      "id":"205",
+      "name":"bkz_caves_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
+      "mapper_name":"pAtq"
+      "mapper_steamid64":"76561197997468889"
+   },
+   {
+      "id":"206",
+      "name":"bkz_cg_coldbhop",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=346170878",
+      "mapper_name":"DaMp"
+   },
+   {
+      "id":"207",
+      "name":"bkz_chillhop_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
+      "mapper_name":"FoF"
+      "mapper_steamid64":"76561197991832101"
+   },
+   {
+      "id":"597",
+      "name":"bkz_dontstop",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=449657758",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"208",
+      "name":"bkz_dydhop",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=784515943",
+      "mapper_name":"dydka",
+      "mapper_steamid64":"76561198010747369"
+   },
+   {
+      "id":"209",
+      "name":"bkz_evanstep",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=842652467",
+      "mapper_name":"Evanstep",
+      "mapper_steamid64":"76561198067339661"
+   },
+   {
+      "id":"551",
+      "name":"bkz_fapzor",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1304605829",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"542",
+      "name":"bkz_fear4",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1251914494",
+      "mapper_name":"Gull",
+      "mapper_steamid64":"76561198137589262"
+   },
+   {
+      "id":"210",
+      "name":"bkz_goldbhop_csgo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=245286254",
+      "mapper_name":"Sprite"
+   },
+   {
+      "id":"211",
+      "name":"bkz_goldbhop_v2go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=343824673",
+      "mapper_name":"Sprite"
+   },
+   {
+      "id":"212",
+      "name":"bkz_hellokitty_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688361403",
+      "mapper_name":"Kore"
+   },
+   {
+      "id":"213",
+      "name":"bkz_impulse",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418436480",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"661",
+      "name":"bkz_iota_v3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1734579951",
+      "mapper_name":"_Max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"767",
+      "name":"bkz_itz_h25l",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2076525905",
+      "mapper_name":"iTz",
+      "mapper_steamid64":"76561198104765796"
+   },
+   {
+      "id":"214",
+      "name":"bkz_levite_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667950111",
+      "mapper_name":"Levite",
+      "mapper_steamid64":"76561198031166668"
+   },
+   {
+      "id":"707",
+      "name":"bkz_lewlysex",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1904095585",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"215",
+      "name":"bkz_measure",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
+      "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
+   },
+   {
+      "id":"216",
+      "name":"bkz_measure2_b03",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
+      "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
+   },
+   {
+      "id":"217",
+      "name":"bkz_nocturns_blue_gfix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
+      "mapper_name":"Levite"
+      "mapper_steamid64":"76561198031166668"
+   },
+   {
+      "id":"827",
+      "name":"bkz_pogo",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2136367398",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"218",
+      "name":"bkz_sahara",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1840329522",
+      "mapper_name":"noko, GameChaos",
+      "mapper_steamid64":"76561198013202660, 76561198165203332"
+   },
+   {
+      "id":"221",
+      "name":"bkz_underground_crypt_v3",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491359928",
+      "mapper_name":"Yaznee"
+   },
+   {
+      "id":"222",
+      "name":"bkz_uninspired_trash",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053096",
+      "mapper_name":"Felicienne"
+   },
+   {
+      "id":"223",
+      "name":"bkz_volcanohop",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=868101976",
+      "mapper_name":"Sprite"
+   },
+   {
+      "id":"820",
+      "name":"bkz_zephyr_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2173494916",
+      "mapper_name":"crixzzi",
+      "mapper_steamid64":"76561198046307458"
+   },
+   {
+      "id":"224",
+      "name":"kzpro_concrete_c02",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519499196",
+      "mapper_name":"ZPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"225",
+      "name":"kzpro_gull_pidr_reborn",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=642418824",
+      "mapper_name":"Gull",
+      "mapper_steamid64":"76561198137589262"
+   },
+   {
+      "id":"737",
+      "name":"kzpro_justrun_sp",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1982407165",
+      "mapper_name":"Saicho",
+      "mapper_steamid64":"76561197995141366"
+   },
+   {
+      "id":"543",
+      "name":"kz_11342",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1155205561",
+      "mapper_name":"persona, geryuganshoop, GameChaos",
+      "mapper_steamid64":"76561198143205331, 76561198068278361, 76561198165203332"
+   },
+   {
+      "id":"566",
+      "name":"kz_11735",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1333248573",
+      "mapper_name":"persona, geryuganshoop",
+      "mapper_steamid64":"76561198143205331, 76561198068278361"
+   },
+   {
+      "id":"226",
+      "name":"kz_21loop_final_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=431789622",
+      "mapper_name":"Gemayue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"885",
+      "name":"kz_2fast",
+      "difficulty":"3",
+      "workshop_url":"http://steamcommunity.com/sharedfiles/filedetails/?id=636149777",
+      "mapper_name":"Gull",
+      "mapper_steamid64":"76561198137589262"
+   },
+   {
+      "id":"227",
+      "name":"kz_2seasons_spring_final",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1242447001",
+      "mapper_name":"Gemayue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"581",
+      "name":"kz_2seasons_winter_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=793414645",
+      "mapper_name":"Gemayue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"870",
+      "name":"kz_420b",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=527350529",
+      "mapper_name":"Gull",
+      "mapper_steamid64":"76561198137589262"
+   },
+   {
+      "id":"228",
+      "name":"kz_4u_nature",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1102436466",
+      "mapper_name":"Ivansky",
+      "mapper_steamid64":"76561198057742312"
+   },
+   {
+      "id":"229",
+      "name":"kz_7in1",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667950835",
+      "mapper_name":"Woozie"
+   },
+   {
+      "id":"862",
+      "name":"kz_8b1_brickngrass",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228982453",
+      "mapper_name":"8ball1, Fenikzz",
+      "mapper_steamid64":"76561198322296161, 76561198152002232"
+   },
+   {
+      "id":"738",
+      "name":"kz_aaaa",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1934946150",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"631",
+      "name":"kz_abandoned",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1581715482",
+      "mapper_name":"Lillen",
+      "mapper_steamid64":"76561198077858937"
+   },
+   {
+      "id":"230",
+      "name":"kz_abstruse_od2",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=841710228",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"231",
+      "name":"kz_adventure_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2233744660",
+      "mapper_name":"Ownkruid, GnargarN",
+      "mapper_steamid64":"76561197985107159, 76561198009902429"
+   },
+   {
+      "id":"232",
+      "name":"kz_adv_cursedjourney",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=248583000",
+      "mapper_name":"Sinful",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"752",
+      "name":"kz_aether_fix",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1901960163",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"642",
+      "name":"kz_afterlife",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1625094133",
+      "mapper_name":"Jony, Broiler",
+      "mapper_steamid64":"76561198000829729, 76561198136166348"
+   },
+   {
+      "id":"233",
+      "name":"kz_after_agitation_easy_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=793417352",
+      "mapper_name":"Gemayue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"234",
+      "name":"kz_agility_v2_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=392863247",
+      "mapper_name":"Aaron"
+   },
+   {
+      "id":"235",
+      "name":"kz_ahful",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580309446",
+      "mapper_name":"Ahful",
+      "mapper_steamid64":"76561198177735294"
+   },
+   {
+      "id":"236",
+      "name":"kz_akrh_warehouse_v2_gfix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575987",
+      "mapper_name":"AssKicR"
+   },
+   {
+      "id":"929",
+      "name":"kz_alfama",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2327257272",
+      "mapper_name":"Rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"662",
+      "name":"kz_alfie",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1360984181",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"237",
+      "name":"kz_alice_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=478203041",
+      "mapper_name":"VVoodchip",
+      "mapper_steamid64":"76561198061948302"
+   },
+   {
+      "id":"759",
+      "name":"kz_alien_city",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2017349111",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"957",
+      "name":"kz_allure",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2423290876",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"922",
+      "name":"kz_alouette_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2347901033",
+      "mapper_name":"Alouette, nopey",
+      "mapper_steamid64":"76561198044981479, 76561198401447544"
+   },
+   {
+      "id":"881",
+      "name":"kz_alpha",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030049320",
+      "mapper_name":"Dima",
+      "mapper_steamid64":"76561198198062889"
+   },
+   {
+      "id":"882",
+      "name":"kz_altum_od",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2241212276",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"768",
+      "name":"kz_alt_aztec",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2069005326",
+      "mapper_name":"SinFuL, fucker",
+      "mapper_steamid64":"76561197970838363, 76561198243661942"
+   },
+   {
+      "id":"785",
+      "name":"kz_alt_cargo",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1947965934",
+      "mapper_name":"eiRa, GameChaos",
+      "mapper_steamid64":"76561197977069783, 76561198165203332"
+   },
+   {
+      "id":"646",
+      "name":"kz_amber_od",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1651410465",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"238",
+      "name":"kz_ancient_v3",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=576216273",
+      "mapper_name":"Verifyy",
+      "mapper_steamid64":"76561197995535364"
+   },
+   {
+      "id":"832",
+      "name":"kz_andromeda",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2193435024",
+      "mapper_name":"TheLlamaKing",
+      "mapper_steamid64":"76561197993284480"
+   },
+   {
+      "id":"830",
+      "name":"kz_angina_final",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2182136940",
+      "mapper_name":"daolang, temmie",
+      "mapper_steamid64":"76561198814294487,  76561198137502865"
+   },
+   {
+      "id":"923",
+      "name":"kz_anotherclimbmap",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2271036340",
+      "mapper_name":"therapysession, nopey",
+      "mapper_steamid64":"76561198012265008, 76561198401447544"
+   },
+   {
+      "id":"826",
+      "name":"kz_antharas",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2137813215",
+      "mapper_name":"Fksch",
+      "mapper_steamid64":"76561198142682783"
+   },
+   {
+      "id":"803",
+      "name":"kz_antigeneric",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2136461557",
+      "mapper_name":"rush2sk8, EchoFrost",
+      "mapper_steamid64":"76561198082904691, 76561198121144282"
+   },
+   {
+      "id":"805",
+      "name":"kz_antimony",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2027793498",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"914",
+      "name":"kz_antiquity",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2275579584",
+      "mapper_name":"JustErroR^, GameChaos",
+      "mapper_steamid64":"76561198150858529, 76561198165203332"
+   },
+   {
+      "id":"801",
+      "name":"kz_anus",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2134749919",
+      "mapper_name":"suna",
+      "mapper_steamid64":"76561198845462726"
+   },
+   {
+      "id":"647",
+      "name":"kz_arbitrary_words",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1658130511",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"239",
+      "name":"kz_arcadium",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1178668090",
+      "mapper_name":"ivansky",
+      "mapper_steamid64":"76561198057742312"
+   },
+   {
+      "id":"629",
+      "name":"kz_arcturus",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1587362542",
+      "mapper_name":"Espoon",
+      "mapper_steamid64":"76561198055373574"
+   },
+   {
+      "id":"939",
+      "name":"kz_armored_core",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381741747",
+      "mapper_name":"J3wDice",
+      "mapper_steamid64":"76561198208729343"
+   },
+   {
+      "id":"240",
+      "name":"kz_arrebol",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=846831175",
+      "mapper_name":"Nthng",
+      "mapper_steamid64":"76561198124649132"
+   },
+   {
+      "id":"241",
+      "name":"kz_ascend_hv",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357729700",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"921",
+      "name":"kz_ashen",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2308615315",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"242",
+      "name":"kz_asphyxiate",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1694955173",
+      "mapper_name":"sqrt, victoria248",
+      "mapper_steamid64":"null, 76561198026839022"
+   },
+   {
+      "id":"243",
+      "name":"kz_asteroid_field_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=333421749",
+      "mapper_name":"SoUlFaThEr",
+      "mapper_steamid64":"76561197965266419"
+   },
+   {
+      "id":"567",
+      "name":"kz_atelectasis_sct",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1887458950",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"684",
+      "name":"kz_athena",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753252198",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198044055747"
+   },
+   {
+      "id":"847",
+      "name":"kz_atlantis_od3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996497943",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"244",
+      "name":"kz_autobadges",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509624370",
+      "mapper_name":"Badges",
+      "mapper_steamid64":"76561197983438223"
+   },
+   {
+      "id":"663",
+      "name":"kz_autumn_valley_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1747171037",
+      "mapper_name":"iBUYFL0WER Birgit",
+      "mapper_steamid64":"76561198078014747"
+   },
+   {
+      "id":"815",
+      "name":"kz_avalon",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2191500128",
+      "mapper_name":"Michael",
+      "mapper_steamid64":"76561198004229810"
+   },
+   {
+      "id":"245",
+      "name":"kz_avoria",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1199062647",
+      "mapper_name":"Smex",
+      "mapper_steamid64":"76561197961558198"
+   },
+   {
+      "id":"246",
+      "name":"kz_aztec",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156057488",
+      "mapper_name":"Sinful",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"635",
+      "name":"kz_azure",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1563199395",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"664",
+      "name":"kz_babycat_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1708424560",
+      "mapper_name":"Schrødna ",
+      "mapper_steamid64":"76561198067192262"
+   },
+   {
+      "id":"598",
+      "name":"kz_bacho",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1481626092",
+      "mapper_name":"Sodawater",
+      "mapper_steamid64":"76561198180483758"
+   },
+   {
+      "id":"871",
+      "name":"kz_backwards",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2236890476",
+      "mapper_name":"Emzatin",
+      "mapper_steamid64":"76561198393292046"
+   },
+   {
+      "id":"247",
+      "name":"kz_bananaysoda_v2",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2156821612",
+      "mapper_name":"Jony, fucker",
+      "mapper_steamid64":"76561198000829729, 76561198243661942"
+   },
+   {
+      "id":"739",
+      "name":"kz_banjo",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753959953",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"248",
+      "name":"kz_basicnoon",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=379026993",
+      "mapper_name":"RVE",
+      "mapper_steamid64":"76561198014015385"
+   },
+   {
+      "id":"249",
+      "name":"kz_basics_b02",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519499813",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"599",
+      "name":"kz_baxter",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1366794864",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"834",
+      "name":"kz_beanguy_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2197490213",
+      "mapper_name":"shnart, Nopey",
+      "mapper_steamid64":"76561198045654331, 76561198401447544"
+   },
+   {
+      "id":"250",
+      "name":"kz_beginnerblock_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156057667",
+      "mapper_name":"Ovi"
+   },
+   {
+      "id":"916",
+      "name":"kz_betapmaps",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2325269071",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"251",
+      "name":"kz_betterdunjun",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=523852277",
+      "mapper_name":"DannyE",
+      "mapper_steamid64":"76561198178232629"
+   },
+   {
+      "id":"894",
+      "name":"kz_bhop_badges2",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1899371128",
+      "mapper_name":"badges, ρ",
+      "mapper_steamid64":"76561197983438223, 76561198002830622"
+   },
+   {
+      "id":"665",
+      "name":"kz_bhop_badges3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1726813996",
+      "mapper_name":"badges, ρ",
+      "mapper_steamid64":"76561197983438223, 76561198002830622"
+   },
+   {
+      "id":"691",
+      "name":"kz_bhop_benchmark",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1776449850",
+      "mapper_name":"badges, ρ",
+      "mapper_steamid64":"76561197983438223, 76561198002830622"
+   },
+   {
+      "id":"634",
+      "name":"kz_bhop_dusk_go",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1617628780",
+      "mapper_name":"CraizZ, ρ",
+      "mapper_steamid64":"76561197993271570, 76561198002830622"
+   },
+   {
+      "id":"252",
+      "name":"kz_bhop_essence",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
+      "mapper_name":"vay"
+      "mapper_steamid64":"76561198131632059"
+   },
+   {
+      "id":"898",
+      "name":"kz_bhop_koki_niwa",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2303161020",
+      "mapper_name":"noko",
+      "mapper_steamid64":"76561198013202660"
+   },
+   {
+      "id":"254",
+      "name":"kz_bhop_lj",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406077055",
+      "mapper_name":"badges",
+      "mapper_steamid64":"76561197983438223"
+   },
+   {
+      "id":"740",
+      "name":"kz_bhop_lucid",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1871085547",
+      "mapper_name":"keyuu, ρ",
+      "mapper_steamid64":"76561198003202977, 76561198002830622"
+   },
+   {
+      "id":"928",
+      "name":"kz_bhop_monsterjam",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2272849539",
+      "mapper_name":"Aoki, GameChaos",
+      "mapper_steamid64":"null, 76561198165203332"
+   },
+   {
+      "id":"582",
+      "name":"kz_bhop_mosaic_od2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=646510868",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"256",
+      "name":"kz_bhop_northface",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=642020842",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"544",
+      "name":"kz_bhop_nothing_go",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1204096299",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"794",
+      "name":"kz_bhop_sakura",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2124488428",
+      "mapper_name":".yuka, TheIceTiger, murray",
+      "mapper_steamid64":"null, 76561198022081031, 76561198019551123"
+   },
+   {
+      "id":"257",
+      "name":"kz_bhop_skyworld_go",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=678315907",
+      "mapper_name":"ρ, Orbit",
+      "mapper_steamid64":"76561198002830622, 76561198057269402"
+   },
+   {
+      "id":"258",
+      "name":"kz_bhop_watertemple",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519457034",
+      "mapper_name":"Daza, SoUlFaThEr, zPrince",
+      "mapper_steamid64":"76561198007996091, 76561197965266419, 76561198047032125"
+   },
+   {
+      "id":"600",
+      "name":"kz_bhop_zenith",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=715243400",
+      "mapper_name":"Zorb, Cyclo",
+      "mapper_steamid64":"76561198144259350, 76561198024466262"
+   },
+   {
+      "id":"624",
+      "name":"kz_bible_black",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1617624549",
+      "mapper_name":"victoria248",
+      "mapper_steamid64":"76561198026839022"
+   },
+   {
+      "id":"920",
+      "name":"kz_bigcastle",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2303795750",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"769",
+      "name":"kz_binseebak",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2096008736",
+      "mapper_name":"L1nus",
+      "mapper_steamid64":"76561198835361052"
+   },
+   {
+      "id":"259",
+      "name":"kz_bionic",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=598309769",
+      "mapper_name":"Zorb",
+      "mapper_steamid64":"76561198144259350"
+   },
+   {
+      "id":"879",
+      "name":"kz_birrita_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240515420",
+      "mapper_name":"HermeticA",
+      "mapper_steamid64":"76561198082476569"
+   },
+   {
+      "id":"741",
+      "name":"kz_bir_dont_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2002208768",
+      "mapper_name":"Bird",
+      "mapper_steamid64":"76561198061987188"
+   },
+   {
+      "id":"641",
+      "name":"kz_blackness",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1582682050",
+      "mapper_name":"Jony",
+      "mapper_steamid64":"76561198000829729"
+   },
+   {
+      "id":"260",
+      "name":"kz_blatherskite_v1",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1201400569",
+      "mapper_name":"DannyE",
+      "mapper_steamid64":"76561198178232629"
+   },
+   {
+      "id":"261",
+      "name":"kz_blindcity_easy_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=673671001",
+      "mapper_name":"GemaYue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"262",
+      "name":"kz_blindcity_hard_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=450945426",
+      "mapper_name":"GemaYue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"618",
+      "name":"kz_blocks2006",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627115733",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"823",
+      "name":"kz_bloodline",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2169096895",
+      "mapper_name":"Makis",
+      "mapper_steamid64":"76561198201492663"
+   },
+   {
+      "id":"263",
+      "name":"kz_bluehop_mq",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1241443665",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"264",
+      "name":"kz_bluerace_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667952586",
+      "mapper_name":"tr4mp"
+   },
+   {
+      "id":"941",
+      "name":"kz_bluuu",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2416991755",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"601",
+      "name":"kz_bombu",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=742494584",
+      "mapper_name":"Bombu",
+      "mapper_steamid64":"76561198217095940"
+   },
+   {
+      "id":"849",
+      "name":"kz_boomblock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2206472013",
+      "mapper_name":"Szwagi",
+      "mapper_steamid64":"76561198857828380"
+   },
+   {
+      "id":"796",
+      "name":"kz_bounce",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2118830049",
+      "mapper_name":"Makis",
+      "mapper_steamid64":"76561198201492663"
+   },
+   {
+      "id":"265",
+      "name":"kz_breezeblocks",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=898027127",
+      "mapper_name":"BreeZ",
+      "mapper_steamid64":"76561198339346625"
+   },
+   {
+      "id":"266",
+      "name":"kz_brickblock_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=621434939",
+      "mapper_name":"masque, DanZay",
+      "mapper_steamid64":"76561197979436335, 76561197989817982"
+   },
+   {
+      "id":"926",
+      "name":"kz_bridge17_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2309106000",
+      "mapper_name":"pr3da, _max",
+      "mapper_steamid64":"76561198021246024, 76561198083065598"
+   },
+   {
+      "id":"267",
+      "name":"kz_brightblock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=653272914",
+      "mapper_name":"bboc",
+      "mapper_steamid64":"76561198000159327"
+   },
+   {
+      "id":"268",
+      "name":"kz_buildings_final",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406077441",
+      "mapper_name":"Vypur",
+      "mapper_steamid64":"76561198027553039"
+   },
+   {
+      "id":"895",
+      "name":"kz_burnished",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2120360302",
+      "mapper_name":"L1nus",
+      "mapper_steamid64":"76561198835361052"
+   },
+   {
+      "id":"911",
+      "name":"kz_byrem",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2327576026",
+      "mapper_name":"Rem, Antosha*",
+      "mapper_steamid64":"76561198072336874, 76561197974898839"
+   },
+   {
+      "id":"686",
+      "name":"kz_cabin_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240379784",
+      "mapper_name":"mjb",
+      "mapper_steamid64":"76561198093921774"
+   },
+   {
+      "id":"270",
+      "name":"kz_camembert",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=808050906",
+      "mapper_name":"BOWql",
+      "mapper_steamid64":"76561198190304705"
+   },
+   {
+      "id":"271",
+      "name":"kz_canyon",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=621630951",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"583",
+      "name":"kz_carbon",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1398723898",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"798",
+      "name":"kz_cargo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279210694",
+      "mapper_name":"eiRa, Alouette",
+      "mapper_steamid64":"null, 76561198044981479"
+   },
+   {
+      "id":"864",
+      "name":"kz_carp_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2241460284",
+      "mapper_name":"Andi, Nopey",
+      "mapper_steamid64":"76561198156668976, 76561198401447544"
+   },
+   {
+      "id":"272",
+      "name":"kz_cartooncastle_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
+      "mapper_name":"s0liD, karatekafer"
+      "mapper_steamid64":"76561197980460370, null"
+   },
+   {
+      "id":"918",
+      "name":"kz_cascade_v4",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2356578123",
+      "mapper_name":"KingGambit",
+      "mapper_steamid64":"76561198023829871"
+   },
+   {
+      "id":"621",
+      "name":"kz_castlehops_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116280",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"274",
+      "name":"kz_cataclysm",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370545981",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"275",
+      "name":"kz_catalyst_gfix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939576543",
+      "mapper_name":"umbrella"
+   },
+   {
+      "id":"276",
+      "name":"kz_catharsis_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=615332047",
+      "mapper_name":"kaldren.",
+      "mapper_steamid64":"76561197972347749"
+   },
+   {
+      "id":"277",
+      "name":"kz_caulis_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058093",
+      "mapper_name":"Millet"
+   },
+   {
+      "id":"568",
+      "name":"kz_cdr_myst",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1391753126",
+      "mapper_name":"Dunk",
+      "mapper_steamid64":"76561197987174004"
+   },
+   {
+      "id":"627",
+      "name":"kz_cdr_rustenborg",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1401830672",
+      "mapper_name":"Dunk",
+      "mapper_steamid64":"76561197987174004"
+   },
+   {
+      "id":"569",
+      "name":"kz_cdr_slash_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1391789057",
+      "mapper_name":"Dunk",
+      "mapper_steamid64":"76561197987174004"
+   },
+   {
+      "id":"760",
+      "name":"kz_celestial",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2059174492",
+      "mapper_name":"mjb",
+      "mapper_steamid64":"76561198093921774"
+   },
+   {
+      "id":"278",
+      "name":"kz_cellblock_go2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058850",
+      "mapper_name":"Millet"
+   },
+   {
+      "id":"814",
+      "name":"kz_cereal",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2176136694",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"279",
+      "name":"kz_cg_brick_rmk",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688171253",
+      "mapper_name":"InseN"
+   },
+   {
+      "id":"280",
+      "name":"kz_cg_lighthops_go",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352286796",
+      "mapper_name":"Mentalo, OldHead",
+      "mapper_steamid64":"null, 76561198009989298"
+   },
+   {
+      "id":"619",
+      "name":"kz_checkmate",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1535993215",
+      "mapper_name":"GameChaos",
+      "mapper_steamid64":"76561198165203332"
+   },
+   {
+      "id":"848",
+      "name":"kz_cheese",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2204525929",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"281",
+      "name":"kz_cheetos_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2234432420",
+      "mapper_name":"pe, Nopey",
+      "mapper_steamid64":"76561198212205417, 76561198401447544"
+   },
+   {
+      "id":"282",
+      "name":"kz_chessblock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=576215645",
+      "mapper_name":"AFlyingGuru"
+   },
+   {
+      "id":"283",
+      "name":"kz_chinablock",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279166189",
+      "mapper_name":"Sinful",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"840",
+      "name":"kz_chloroplast",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2194393186",
+      "mapper_name":"Plastyc",
+      "mapper_steamid64":"76561199024218227"
+   },
+   {
+      "id":"742",
+      "name":"kz_choka_fix",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1933623975",
+      "mapper_name":"JJ",
+      "mapper_steamid64":"76561198167125526"
+   },
+   {
+      "id":"897",
+      "name":"kz_chopchop",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187656713",
+      "mapper_name":"Sehk",
+      "mapper_steamid64":"76561198037724970"
+   },
+   {
+      "id":"284",
+      "name":"kz_christmas_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=669198796",
+      "mapper_name":"geryuganshoop",
+      "mapper_steamid64":"76561198068278361"
+   },
+   {
+      "id":"892",
+      "name":"kz_chrysoprase",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2237697111",
+      "mapper_name":"Michael",
+      "mapper_steamid64":"76561198004229810"
+   },
+   {
+      "id":"902",
+      "name":"kz_chunky_peanut_butter",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259665094",
+      "mapper_name":"rov",
+      "mapper_steamid64":"76561198132236283"
+   },
+   {
+      "id":"636",
+      "name":"kz_citadel",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1546644939",
+      "mapper_name":"aleiux",
+      "mapper_steamid64":"76561198090798444"
+   },
+   {
+      "id":"753",
+      "name":"kz_civilizations",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2034478444",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"285",
+      "name":"kz_cliffhanger_go_global",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=504851319",
+      "mapper_name":"Blind",
+      "mapper_steamid64":"76561198152317855"
+   },
+   {
+      "id":"825",
+      "name":"kz_coastline_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2171603497",
+      "mapper_name":"Steelo, Nopey",
+      "mapper_steamid64":"76561198279205361, 76561198401447544"
+   },
+   {
+      "id":"286",
+      "name":"kz_colorcode",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=528597060",
+      "mapper_name":"schm0ftie",
+      "mapper_steamid64":"76561197983561860"
+   },
+   {
+      "id":"287",
+      "name":"kz_colors_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=325027910",
+      "mapper_name":"Wally",
+      "mapper_steamid64":"76561197967777192"
+   },
+   {
+      "id":"288",
+      "name":"kz_combobreaker",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=908525075",
+      "mapper_name":"GameChaos",
+      "mapper_steamid64":"76561198165203332"
+   },
+   {
+      "id":"289",
+      "name":"kz_combohop_c02",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519498732",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"570",
+      "name":"kz_comboya",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1256315105",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"290",
+      "name":"kz_communityjump3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=659804813",
+      "mapper_name":"KZ Community"
+   },
+   {
+      "id":"291",
+      "name":"kz_complex",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=386875795",
+      "mapper_name":"teh_grave, DropInMilk",
+      "mapper_steamid64":"null, 76561198033385282"
+   },
+   {
+      "id":"292",
+      "name":"kz_comp_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053614",
+      "mapper_name":"ella",
+      "mapper_steamid64":"76561198069465729"
+   },
+   {
+      "id":"293",
+      "name":"kz_concept",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=903732207",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"294",
+      "name":"kz_concretejungle",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=506427184",
+      "mapper_name":"rev",
+      "mapper_steamid64":"76561197981308142"
+   },
+   {
+      "id":"650",
+      "name":"kz_conifer",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1699121278",
+      "mapper_name":"victoria248, GameChaos",
+      "mapper_steamid64":"76561198026839022, 76561198165203332"
+   },
+   {
+      "id":"295",
+      "name":"kz_conrun_mq",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=381648804",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"296",
+      "name":"kz_conrun_scrub",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=382262763",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"297",
+      "name":"kz_conspiracy",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=896555313",
+      "mapper_name":"Jakobe",
+      "mapper_steamid64":"76561198072850237"
+   },
+   {
+      "id":"298",
+      "name":"kz_construction",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=499184114",
+      "mapper_name":"finckelton",
+      "mapper_steamid64":"76561198039388458"
+   },
+   {
+      "id":"683",
+      "name":"kz_continuum",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1464119184",
+      "mapper_name":"Crash",
+      "mapper_steamid64":"76561197981212562"
+   },
+   {
+      "id":"552",
+      "name":"kz_coronado_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1381132298",
+      "mapper_name":"Cyclo",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"602",
+      "name":"kz_correguachin_reisido",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187796868",
+      "mapper_name":"Shendal",
+      "mapper_steamid64":"76561198225775664"
+   },
+   {
+      "id":"545",
+      "name":"kz_cousucks",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1241648205",
+      "mapper_name":"Krushed",
+      "mapper_steamid64":"76561197966948458"
+   },
+   {
+      "id":"943",
+      "name":"kz_cranking_the_hog",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381788599",
+      "mapper_name":"rov",
+      "mapper_steamid64":"76561198132236283"
+   },
+   {
+      "id":"828",
+      "name":"kz_crash_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2163399474",
+      "mapper_name":"Alouette, nopey",
+      "mapper_steamid64":"76561198044981479, 76561198401447544"
+   },
+   {
+      "id":"299",
+      "name":"kz_cratespeed",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=689965741",
+      "mapper_name":"ruben",
+      "mapper_steamid64":"76561198100183392"
+   },
+   {
+      "id":"300",
+      "name":"kz_crate_delight_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491405849",
+      "mapper_name":"SoUlFaThEr, zPrince",
+      "mapper_steamid64":"76561197965266419, 76561198047032125"
+   },
+   {
+      "id":"301",
+      "name":"kz_crypt_final",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=528128872",
+      "mapper_name":"Ryborg",
+      "mapper_steamid64":"76561198101913104"
+   },
+   {
+      "id":"302",
+      "name":"kz_crysis",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387238555",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"953",
+      "name":"kz_cuberunfast",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2420438992",
+      "mapper_name":"DannyE",
+      "mapper_steamid64":"76561198178232629"
+   },
+   {
+      "id":"303",
+      "name":"kz_custos",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1135144334",
+      "mapper_name":"xq, GameChaos",
+      "mapper_steamid64":"76561198094382485, 76561198165203332"
+   },
+   {
+      "id":"712",
+      "name":"kz_cyberspace_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996119569",
+      "mapper_name":"Charon",
+      "mapper_steamid64":"76561197979938663"
+   },
+   {
+      "id":"304",
+      "name":"kz_cyb_adrenaline_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1780391218",
+      "mapper_name":"cybur, masque",
+      "mapper_steamid64":"76561198062384407, 76561197979436335"
+   },
+   {
+      "id":"553",
+      "name":"kz_dakow",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1278987653",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"613",
+      "name":"kz_dale",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116834",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"305",
+      "name":"kz_dam",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=647694230",
+      "mapper_name":"pr3da",
+      "mapper_steamid64":"76561198021246024"
+   },
+   {
+      "id":"306",
+      "name":"kz_daniel",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=416827844",
+      "mapper_name":"Khaleese",
+      "mapper_steamid64":"76561198123676539"
+   },
+   {
+      "id":"770",
+      "name":"kz_dank_stacks",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2075152351",
+      "mapper_name":"DankD",
+      "mapper_steamid64":"76561198039728576"
+   },
+   {
+      "id":"924",
+      "name":"kz_dark_fury",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2380315439",
+      "mapper_name":"sn00p, ρ",
+      "mapper_steamid64":"null, 76561198002830622"
+   },
+   {
+      "id":"307",
+      "name":"kz_date2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406439108",
+      "mapper_name":"s0liD, DropInMilk",
+      "mapper_steamid64":"76561197980460370, 76561198033385282"
+   },
+   {
+      "id":"308",
+      "name":"kz_default",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=382377001",
+      "mapper_name":"DropinMilk",
+      "mapper_steamid64":"76561198033385282"
+   },
+   {
+      "id":"622",
+      "name":"kz_dejavu",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1539800895",
+      "mapper_name":"Fnugz",
+      "mapper_steamid64":"76561198012891563"
+   },
+   {
+      "id":"811",
+      "name":"kz_delphinium",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2145751608",
+      "mapper_name":"Michael",
+      "mapper_steamid64":"76561198004229810"
+   },
+   {
+      "id":"309",
+      "name":"kz_depot",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=738046973",
+      "mapper_name":"f3vo",
+      "mapper_steamid64":"76561198040677227"
+   },
+   {
+      "id":"554",
+      "name":"kz_dethroned",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1295359223",
+      "mapper_name":"Cyclo",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"310",
+      "name":"kz_de_bhop",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509624659"
+   },
+   {
+      "id":"651",
+      "name":"kz_diajonal",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1626046474",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"311",
+      "name":"kz_dimensions_v1",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491411804",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"312",
+      "name":"kz_district_d01",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=421427380",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"908",
+      "name":"kz_divided",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2330433609",
+      "mapper_name":"J3wDice",
+      "mapper_steamid64":"76561198208729343"
+   },
+   {
+      "id":"925",
+      "name":"kz_dontjump",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2276652300",
+      "mapper_name":"Emzatin",
+      "mapper_steamid64":"76561198393292046"
+   },
+   {
+      "id":"313",
+      "name":"kz_doubletake",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491377297",
+      "mapper_name":"BeastF",
+      "mapper_steamid64":"76561197992587981"
+   },
+   {
+      "id":"314",
+      "name":"kz_doveen",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=391996291",
+      "mapper_name":"DoveeN",
+      "mapper_steamid64":"76561198033299991"
+   },
+   {
+      "id":"315",
+      "name":"kz_drops_od",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=631559848",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"937",
+      "name":"kz_drunkards",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2422272884",
+      "mapper_name":"Plastyc",
+      "mapper_steamid64":"76561199024218227"
+   },
+   {
+      "id":"316",
+      "name":"kz_dryness",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=611091154",
+      "mapper_name":"pr3da",
+      "mapper_steamid64":"76561198021246024"
+   },
+   {
+      "id":"317",
+      "name":"kz_duality_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1851066208",
+      "mapper_name":"VVoodchip, Zach47",
+      "mapper_steamid64":"76561198061948302, 76561197983014207"
+   },
+   {
+      "id":"318",
+      "name":"kz_dungeon",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515635506",
+      "mapper_name":"RyBorg",
+      "mapper_steamid64":"76561198101913104"
+   },
+   {
+      "id":"850",
+      "name":"kz_dust",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187288428",
+      "mapper_name":"L1nus",
+      "mapper_steamid64":"76561198835361052"
+   },
+   {
+      "id":"319",
+      "name":"kz_dvn_cube_fixed",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498765580",
+      "mapper_name":"DoveeN",
+      "mapper_steamid64":"76561198033299991"
+   },
+   {
+      "id":"320",
+      "name":"kz_dvn_dull",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=483073135",
+      "mapper_name":"DoveeN",
+      "mapper_steamid64":"76561198033299991"
+   },
+   {
+      "id":"321",
+      "name":"kz_dvn_redcarpet",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=605822998",
+      "mapper_name":"DoveeN",
+      "mapper_steamid64":"76561198033299991"
+   },
+   {
+      "id":"713",
+      "name":"kz_dyd_ladderjumps",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1653452291",
+      "mapper_name":"dydka, GameChaos",
+      "mapper_steamid64":"76561198010747369, 76561198165203332"
+   },
+   {
+      "id":"322",
+      "name":"kz_dzy_beyond_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=454227310",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"323",
+      "name":"kz_dzy_reach_v2",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=673887976",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"324",
+      "name":"kz_ea_beneath_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=338561631",
+      "mapper_name":"rad0n, old head",
+      "mapper_steamid64":"null, 76561198009989298"
+   },
+   {
+      "id":"873",
+      "name":"kz_echo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259659098",
+      "mapper_name":"mjb",
+      "mapper_steamid64":"76561198093921774"
+   },
+   {
+      "id":"325",
+      "name":"kz_edifice",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=930321498",
+      "mapper_name":"Crixzzi",
+      "mapper_steamid64":"76561198046307458"
+   },
+   {
+      "id":"667",
+      "name":"kz_edp445",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1755737510",
+      "mapper_name":"victoria248",
+      "mapper_steamid64":"76561198026839022"
+   },
+   {
+      "id":"623",
+      "name":"kz_egyptianbox",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1576706552",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"326",
+      "name":"kz_emblem",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=489591399",
+      "mapper_name":"SinFul, Timmycakes",
+      "mapper_steamid64":"76561197970838363, 0"
+   },
+   {
+      "id":"327",
+      "name":"kz_emblem_bonus",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491412109",
+      "mapper_name":"SinFul, Timmycakes",
+      "mapper_steamid64":"76561197970838363, 0"
+   },
+   {
+      "id":"838",
+      "name":"kz_emptiness",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2203626680",
+      "mapper_name":"SneakY",
+      "mapper_steamid64":"76561198251129150"
+   },
+   {
+      "id":"328",
+      "name":"kz_ephemeral",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=692077375",
+      "mapper_name":"Tapzie",
+      "mapper_steamid64":"76561198122678894"
+   },
+   {
+      "id":"584",
+      "name":"kz_epiphany_v2",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1386147078",
+      "mapper_name":"Cyclo",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"329",
+      "name":"kz_epusbridge",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=303863578",
+      "mapper_name":"Deepus",
+      "mapper_steamid64":"76561197976153012"
+   },
+   {
+      "id":"930",
+      "name":"kz_erbajerb",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2304761102",
+      "mapper_name":"Birgit",
+      "mapper_steamid64":"76561198078014747"
+   },
+   {
+      "id":"330",
+      "name":"kz_erinome",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=568096729",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"331",
+      "name":"kz_eros_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=791910412",
+      "mapper_name":"finckelton, Kiwi",
+      "mapper_steamid64":"76561198039388458, 76561198077353609"
+   },
+   {
+      "id":"546",
+      "name":"kz_erratum_v2",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170612689",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"936",
+      "name":"kz_eudora",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2312833379",
+      "mapper_name":"nowimime",
+      "mapper_steamid64":"76561198077383803"
+   },
+   {
+      "id":"585",
+      "name":"kz_eventide",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1382667484",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"799",
+      "name":"kz_everything",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2069925634",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"714",
+      "name":"kz_evilcorp",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1904796339",
+      "mapper_name":"Magier",
+      "mapper_steamid64":"76561198103471850"
+   },
+   {
+      "id":"332",
+      "name":"kz_excape",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406079956",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64": "76561198040798967"
+   },
+   {
+      "id":"333",
+      "name":"kz_excavate_b",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1440554662",
+      "mapper_name":"Badges",
+      "mapper_steamid64":"76561197983438223"
+   },
+   {
+      "id":"831",
+      "name":"kz_exemplum_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228224629",
+      "mapper_name":"Makis",
+      "mapper_steamid64":"76561198201492663"
+   },
+   {
+      "id":"334",
+      "name":"kz_exoteric",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=380505617",
+      "mapper_name":"Energy",
+      "mapper_steamid64":"76561198084022373"
+   },
+   {
+      "id":"335",
+      "name":"kz_experiment",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=398489890",
+      "mapper_name":"TheWhaleMan",
+      "mapper_steamid64":"76561198064508818"
+   },
+   {
+      "id":"336",
+      "name":"kz_exps_cursedjourney",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=525288912",
+      "mapper_name":"SinFul",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"337",
+      "name":"kz_ext_bblocks",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352448183",
+      "mapper_name":"Extermerz"
+   },
+   {
+      "id":"338",
+      "name":"kz_fabrik",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=221328962",
+      "mapper_name":"Snorres",
+      "mapper_steamid64":"76561197986556153"
+   },
+   {
+      "id":"339",
+      "name":"kz_failed_fastrun_rt",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688361058",
+      "mapper_name":"0n1yF4r7"
+   },
+   {
+      "id":"692",
+      "name":"kz_farm_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1750701302",
+      "mapper_name":"Chris, GameChaos",
+      "mapper_steamid64":"76561198044472964, 76561198165203332"
+   },
+   {
+      "id":"693",
+      "name":"kz_fas2map",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1699101066",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"340",
+      "name":"kz_fastcombomap",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=760052560",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"603",
+      "name":"kz_fastmap",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1448528308",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"341",
+      "name":"kz_fatigue_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=375133191",
+      "mapper_name":"Energy",
+      "mapper_steamid64":"76561198084022373"
+   },
+   {
+      "id":"342",
+      "name":"kz_fikablock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=674086581",
+      "mapper_name":"Jmonsted",
+      "mapper_steamid64":"76561198071182150"
+   },
+   {
+      "id":"343",
+      "name":"kz_final_ascension",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=551807622",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"694",
+      "name":"kz_flabbergast",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1770987028",
+      "mapper_name":"CyclO",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"344",
+      "name":"kz_floatingislands",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=738956347",
+      "mapper_name":"lillen",
+      "mapper_steamid64":"76561198077858937"
+   },
+   {
+      "id":"614",
+      "name":"kz_flying_rabbits",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627117444",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"888",
+      "name":"kz_fly_lovers",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2012561467",
+      "mapper_name":"Deppy, persona",
+      "mapper_steamid64":"null, 76561198143205331"
+   },
+   {
+      "id":"345",
+      "name":"kz_foggywarehouse_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387995227",
+      "mapper_name":"pb",
+      "mapper_steamid64":"76561197971221508"
+   },
+   {
+      "id":"253",
+      "name":"kz_forchi",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1860299808",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"346",
+      "name":"kz_forestrace_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=337879628",
+      "mapper_name":"h1m1, old head",
+      "mapper_steamid64":"null, 76561198009989298"
+   },
+   {
+      "id":"695",
+      "name":"kz_forgettable",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1399481815",
+      "mapper_name":"River",
+      "mapper_steamid64":"76561198054436805"
+   },
+   {
+      "id":"547",
+      "name":"kz_forgotten_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1213870327",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"347",
+      "name":"kz_free_ahful",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1167761258",
+      "mapper_name":"Persona",
+      "mapper_steamid64":"76561198143205331"
+   },
+   {
+      "id":"348",
+      "name":"kz_frozen_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066122",
+      "mapper_name":"SoUlFaThEr, SinFuL",
+      "mapper_steamid64":"76561197965266419, 76561197970838363"
+   },
+   {
+      "id":"884",
+      "name":"kz_fury",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224298709",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"652",
+      "name":"kz_fused",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1715598348",
+      "mapper_name":"mjb",
+      "mapper_steamid64":"76561198093921774"
+   },
+   {
+      "id":"349",
+      "name":"kz_futureblock",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320897168",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"350",
+      "name":"kz_galaxy_go2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066234",
+      "mapper_name":"Woozie"
+   },
+   {
+      "id":"548",
+      "name":"kz_gallus",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=890259285",
+      "mapper_name":"Karo, Diesel",
+      "mapper_steamid64":"76561198059165508, 76561198099241969"
+   },
+   {
+      "id":"913",
+      "name":"kz_gary",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2280509631",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"474",
+      "name":"kz_gc_shark",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2080951339",
+      "mapper_name":"nykaN, GameChaos",
+      "mapper_steamid64":"76561198014491259, 76561198165203332"
+   },
+   {
+      "id":"643",
+      "name":"kz_gemischte_gefuehlslagen",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1280314788",
+      "mapper_name":"Heinzelboss",
+      "mapper_steamid64":"76561198155043164"
+   },
+   {
+      "id":"761",
+      "name":"kz_generic",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2047349909",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"351",
+      "name":"kz_genesis_go2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
+      "mapper_name":"FoF"
+      "mapper_steamid64":"76561197991832101"
+   },
+   {
+      "id":"352",
+      "name":"kz_gfy_blueberry",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=336069751",
+      "mapper_name":"Wally",
+      "mapper_steamid64":"76561197967777192"
+   },
+   {
+      "id":"353",
+      "name":"kz_gfy_c0mb0king",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352458126",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"354",
+      "name":"kz_gfy_devcastle",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399926903",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"355",
+      "name":"kz_gfy_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=438483912",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"356",
+      "name":"kz_gfy_fortroca_finallll",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352459359",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"357",
+      "name":"kz_gfy_limit",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=441312733",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"358",
+      "name":"kz_gfy_strawberry_",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352456857",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"359",
+      "name":"kz_gfy_tech",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409983599",
+      "mapper_name":"winterNebs",
+      "mapper_steamid64":"76561198040798967"
+   },
+   {
+      "id":"360",
+      "name":"kz_ggurk",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1139544827",
+      "mapper_name":"AFlyingGuru, Flow",
+      "mapper_steamid64":"null, 76561197991750093"
+   },
+   {
+      "id":"617",
+      "name":"kz_ghat",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118013",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"361",
+      "name":"kz_giantbean",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066438",
+      "mapper_name":"KreedZ, SinFuL",
+      "mapper_steamid64":"76561197997103423, 76561197970838363"
+   },
+   {
+      "id":"362",
+      "name":"kz_gigablock_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
+      "mapper_name":"KreedZ, Spherix",
+      "mapper_steamid64":"76561198016516359, null"
+   },
+   {
+      "id":"363",
+      "name":"kz_gitgud_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370366679",
+      "mapper_name":"VypuR",
+      "mapper_steamid64":"76561198027553039"
+   },
+   {
+      "id":"863",
+      "name":"kz_gkd_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240110192",
+      "mapper_name":"Ap",
+      "mapper_steamid64":"76561198331631430"
+   },
+   {
+      "id":"364",
+      "name":"kz_glassesospa_v1",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=212501969",
+      "mapper_name":"Ospa",
+      "mapper_steamid64":"76561197992548863"
+   },
+   {
+      "id":"804",
+      "name":"kz_glide",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1816942862",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"668",
+      "name":"kz_gloom",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1747028736",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"653",
+      "name":"kz_gobbledygook",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1458270387",
+      "mapper_name":"J4BEE, Persona",
+      "mapper_steamid64":"76561198168982111, 76561198143205331"
+   },
+   {
+      "id":"365",
+      "name":"kz_goldenroad",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=227198727",
+      "mapper_name":"Ospa, Al2x",
+      "mapper_steamid64":"76561197992548863, 76561198037766292"
+   },
+   {
+      "id":"696",
+      "name":"kz_goldentabby",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1742520143",
+      "mapper_name":"ShadowBladeXtrm",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"366",
+      "name":"kz_gonbe",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=388981512",
+      "mapper_name":"skitty",
+      "mapper_steamid64":"76561198031452487"
+   },
+   {
+      "id":"367",
+      "name":"kz_goodluck_p",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=315108801",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"638",
+      "name":"kz_goquicklol_v2",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1674495693",
+      "mapper_name":"Mark",
+      "mapper_steamid64":"76561198045869085"
+   },
+   {
+      "id":"368",
+      "name":"kz_grass_hard",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491359087",
+      "mapper_name":"Extremerz",
+      "mapper_steamid64":"76561197965479288"
+   },
+   {
+      "id":"369",
+      "name":"kz_green",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=425209295",
+      "mapper_name":"Piu",
+      "mapper_steamid64":"76561198014009703"
+   },
+   {
+      "id":"370",
+      "name":"kz_gy_agitation",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=444123619",
+      "mapper_name":"Gemayue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"371",
+      "name":"kz_haki_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066638",
+      "mapper_name":"a$ce"
+   },
+   {
+      "id":"499",
+      "name":"kz_halicarnassus_fs",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2080802644",
+      "mapper_name":"Zengal, SinFuL",
+      "mapper_steamid64":"null, 76561197970838363"
+   },
+   {
+      "id":"792",
+      "name":"kz_hammer",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2133476426",
+      "mapper_name":"Makis",
+      "mapper_steamid64":"76561198201492663"
+   },
+   {
+      "id":"717",
+      "name":"kz_haste",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1877331884",
+      "mapper_name":"Dillon",
+      "mapper_steamid64":"76561198120868833"
+   },
+   {
+      "id":"372",
+      "name":"kz_hate",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=875611390",
+      "mapper_name":"Yams",
+      "mapper_steamid64":"76561198348576275"
+   },
+   {
+      "id":"373",
+      "name":"kz_heatvents_mq",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=459351652",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"697",
+      "name":"kz_heaven_od",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1705891534",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"843",
+      "name":"kz_hek",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2175513019",
+      "mapper_name":"Pigeon",
+      "mapper_steamid64":"76561198164405482"
+   },
+   {
+      "id":"374",
+      "name":"kz_hellinashop",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515649978",
+      "mapper_name":"8Ball1, SinFuL",
+      "mapper_steamid64":"null, 76561197970838363"
+   },
+   {
+      "id":"839",
+      "name":"kz_hemochromatosis",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2044616297",
+      "mapper_name":"rov",
+      "mapper_steamid64":"76561198132236283"
+   },
+   {
+      "id":"375",
+      "name":"kz_highland",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=656212893",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"719",
+      "name":"kz_high_socks",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1984921434",
+      "mapper_name":"GameChaos, Samuel",
+      "mapper_steamid64":"76561198165203332, 76561198191875674"
+   },
+   {
+      "id":"586",
+      "name":"kz_hikari_od",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=884785011",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"377",
+      "name":"kz_hillside",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
+      "mapper_name":"s0liD"
+      "mapper_steamid64":"76561197980460370"
+   },
+   {
+      "id":"376",
+      "name":"kz_hitech",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2002217295",
+      "mapper_name":"nykaN",
+      "mapper_steamid64":"76561198014491259"
+   },
+   {
+      "id":"681",
+      "name":"kz_holyspace",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1771753813",
+      "mapper_name":"SodaWater",
+      "mapper_steamid64":"76561198180483758"
+   },
+   {
+      "id":"817",
+      "name":"kz_how2slide_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2166904834",
+      "mapper_name":"Dima",
+      "mapper_steamid64":"76561198198062889"
+   },
+   {
+      "id":"720",
+      "name":"kz_huber",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1702853550",
+      "mapper_name":"Durox",
+      "mapper_steamid64":"76561198072521803"
+   },
+   {
+      "id":"378",
+      "name":"kz_ickkck",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=822776276",
+      "mapper_name":"Rosquilla Guy",
+      "mapper_steamid64":"76561198102575797"
+   },
+   {
+      "id":"379",
+      "name":"kz_illusion_gfix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939577141",
+      "mapper_name":"schm0ftie",
+      "mapper_steamid64":"76561197983561860"
+   },
+   {
+      "id":"380",
+      "name":"kz_iluvprok_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053852",
+      "mapper_name":"Nitekillr",
+      "mapper_steamid64":"76561197987002717"
+   },
+   {
+      "id":"381",
+      "name":"kz_imaginary_final",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=843659203",
+      "mapper_name":"JONY",
+      "mapper_steamid64":"76561198000829729"
+   },
+   {
+      "id":"382",
+      "name":"kz_innit",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1209786787",
+      "mapper_name":"bainz, GameChaos, Danvari",
+      "mapper_steamid64":"76561198183817078, 76561198165203332, 76561198038388449"
+   },
+   {
+      "id":"383",
+      "name":"kz_insomnia_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=594168198",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"384",
+      "name":"kz_inspired",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370117755",
+      "mapper_name":"Kaldren",
+      "mapper_steamid64":"76561197972347749"
+   },
+   {
+      "id":"860",
+      "name":"kz_intercourse!",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207574101",
+      "mapper_name":"stz",
+      "mapper_steamid64":"76561198261992780"
+   },
+   {
+      "id":"385",
+      "name":"kz_internatus",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=551443219",
+      "mapper_name":"Deepus",
+      "mapper_steamid64":"76561197976153012"
+   },
+   {
+      "id":"386",
+      "name":"kz_island",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357579568",
+      "mapper_name":"JumBoO",
+      "mapper_steamid64":"7656119813262611"
+   },
+   {
+      "id":"950",
+      "name":"kz_itz_transcendent",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2373968399",
+      "mapper_name":"iTz",
+      "mapper_steamid64":"76561198104765796"
+   },
+   {
+      "id":"387",
+      "name":"kz_j2s_cupblock_go_fix2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
+      "mapper_name":"s0lid, Spherix"
+      "mapper_steamid64":"76561197980460370, null"
+   },
+   {
+      "id":"388",
+      "name":"kz_j2s_tetris_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
+      "mapper_name":"s0lid, fl0w",
+      "mapper_steamid64":"76561197980460370, 76561197991750093"
+   },
+   {
+      "id":"389",
+      "name":"kz_j2s_westbl0ck",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
+      "mapper_name":"s0lid, fl0w, DanZay",
+      "mapper_steamid64":"76561197980460370, 76561197991750093, 76561197989817982"
+   },
+   {
+      "id":"390",
+      "name":"kz_janpu_final_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357085110",
+      "mapper_name":"Verifyy",
+      "mapper_steamid64":"76561197995535364"
+   },
+   {
+      "id":"391",
+      "name":"kz_jg_ditch",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=367347758",
+      "mapper_name":"ticK!",
+      "mapper_steamid64":"76561198171545305"
+   },
+   {
+      "id":"754",
+      "name":"kz_johndoe",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2015357272",
+      "mapper_name":"Bolo",
+      "mapper_steamid64":"76561198297512910"
+   },
+   {
+      "id":"392",
+      "name":"kz_jump_n_run",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=629040765",
+      "mapper_name":"Smex",
+      "mapper_steamid64":"76561197961558198"
+   },
+   {
+      "id":"889",
+      "name":"kz_kat_colorblind",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2277557067",
+      "mapper_name":"katz, rush2sk8",
+      "mapper_steamid64":"76561198067576863, 76561198082904691"
+   },
+   {
+      "id":"952",
+      "name":"kz_kiwiexultation",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2415258457",
+      "mapper_name":"Kiwi",
+      "mapper_steamid64":"76561198077353609"
+   },
+   {
+      "id":"844",
+      "name":"kz_kiwitech",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2229046768",
+      "mapper_name":"Kiwi",
+      "mapper_steamid64":"76561198077353609"
+   },
+   {
+      "id":"951",
+      "name":"kz_kiwiterror",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2413286682",
+      "mapper_name":"Kiwi",
+      "mapper_steamid64":"76561198077353609"
+   },
+   {
+      "id":"932",
+      "name":"kz_kiwi_cod",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2256093157",
+      "mapper_name":"Kiwi, CoD",
+      "mapper_steamid64":"76561198077353609, 76561198846255522"
+   },
+   {
+      "id":"800",
+      "name":"kz_kohze_sucks",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2130097882",
+      "mapper_name":"Krushed",
+      "mapper_steamid64":"76561197966948458"
+   },
+   {
+      "id":"394",
+      "name":"kz_kzinga_fixed",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=455178914",
+      "mapper_name":"finckelton",
+      "mapper_steamid64":"76561198039388458"
+   },
+   {
+      "id":"762",
+      "name":"kz_kzra_bars",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1901874741",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"763",
+      "name":"kz_kzra_cliffy",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1912922798",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"771",
+      "name":"kz_kzra_hohum",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1877338856",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"682",
+      "name":"kz_kzra_morath",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1761949860",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"793",
+      "name":"kz_kzra_oddland",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2105252723",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"669",
+      "name":"kz_kzra_shortclimb_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753701773",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"699",
+      "name":"kz_kzra_skaxis",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1846345249",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"700",
+      "name":"kz_kzra_slidely",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1816052873",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"887",
+      "name":"kz_kzra_slidepuf",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1824161798",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"851",
+      "name":"kz_kzra_stoneishbhop",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207370784",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"701",
+      "name":"kz_kzra_voovblock",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1795477339",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"685",
+      "name":"kz_kzra_whitesquare",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1793270481",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"772",
+      "name":"kz_kzro_brickstgrass_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2235348857",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"866",
+      "name":"kz_kzro_bronea",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2237646194",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"808",
+      "name":"kz_kzro_gohome",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2117028264",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"867",
+      "name":"kz_kzro_hardvalley",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215405289",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"786",
+      "name":"kz_kzro_mountainbhop",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2118958853",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"906",
+      "name":"kz_kzro_mountainsein",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207874525",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"896",
+      "name":"kz_kzro_mountainsnow",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2230533130",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"883",
+      "name":"kz_kzro_slidesmear",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2239093087",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"845",
+      "name":"kz_kzro_sunmountainset",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2222540470",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"395",
+      "name":"kz_kzse_aztectemple",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=302894093",
+      "mapper_name":"Sinful",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"791",
+      "name":"kz_ladderall",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2124189658",
+      "mapper_name":"Cou",
+      "mapper_steamid64":"76561198007928944"
+   },
+   {
+      "id":"833",
+      "name":"kz_ladderdespair",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2191784508",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"755",
+      "name":"kz_ladderhell_fix",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2034623068",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"396",
+      "name":"kz_lavablock_global",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406054554",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"900",
+      "name":"kz_layercake",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2255773578",
+      "mapper_name":"Downie2K",
+      "mapper_steamid64":"76561197981037626"
+   },
+   {
+      "id":"788",
+      "name":"kz_lazy",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2105506029",
+      "mapper_name":"Michael, Haakz",
+      "mapper_steamid64":"76561198004229810, 76561197990350366"
+   },
+   {
+      "id":"397",
+      "name":"kz_lego",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=351298054",
+      "mapper_name":"DutchSnowman",
+      "mapper_steamid64":"76561198027507070"
+   },
+   {
+      "id":"398",
+      "name":"kz_lego_two_redux_v3",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515550870",
+      "mapper_name":"DutchSnowman",
+      "mapper_steamid64":"76561198027507070"
+   },
+   {
+      "id":"399",
+      "name":"kz_levels",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=635973918",
+      "mapper_name":"Jurkelis",
+      "mapper_steamid64":"76561198071655291"
+   },
+   {
+      "id":"400",
+      "name":"kz_life_final",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=683576131",
+      "mapper_name":"Chaosangel",
+      "mapper_steamid64":"76561198078333036"
+   },
+   {
+      "id":"721",
+      "name":"kz_lionheart",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1805200433",
+      "mapper_name":"iBUYFL0WER Birgit, nutsdoodle",
+      "mapper_steamid64":"76561198078014747, 76561198150143219"
+   },
+   {
+      "id":"819",
+      "name":"kz_list_gnida_v2",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=630032870",
+      "mapper_name":"DeadRote",
+      "mapper_steamid64":"76561198034507626"
+   },
+   {
+      "id":"401",
+      "name":"kz_littlerock_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156067138",
+      "mapper_name":"Surion"
+   },
+   {
+      "id":"917",
+      "name":"kz_loathe",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1961922598",
+      "mapper_name":"JJ",
+      "mapper_steamid64":"76561198167125526"
+   },
+   {
+      "id":"842",
+      "name":"kz_longjumps_easy",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
+      "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
+   },
+   {
+      "id":"604",
+      "name":"kz_longjumps_space",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=637925784",
+      "mapper_name":"JONY, CyclO",
+      "mapper_steamid64":"76561198000829729, 76561198024466262"
+   },
+   {
+      "id":"876",
+      "name":"kz_lookout",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2245294640",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"644",
+      "name":"kz_lost_marketplace_gfix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939577604",
+      "mapper_name":"JONY, Rosquilla Guy",
+      "mapper_steamid64":"76561198000829729, 76561198102575797"
+   },
+   {
+      "id":"933",
+      "name":"kz_lovely",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2227118054",
+      "mapper_name":"makis",
+      "mapper_steamid64":"76561198201492663"
+   },
+   {
+      "id":"403",
+      "name":"kz_lume",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=717341154",
+      "mapper_name":"VVoodchip",
+      "mapper_steamid64":"76561198061948302"
+   },
+   {
+      "id":"404",
+      "name":"kz_luonto",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1102578759",
+      "mapper_name":"sBlisss, GameChaos",
+      "mapper_steamid64":"null, 76561198165203332"
+   },
+   {
+      "id":"938",
+      "name":"kz_luv_less",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2350173887",
+      "mapper_name":"J3wDice",
+      "mapper_steamid64":"76561198208729343"
+   },
+   {
+      "id":"405",
+      "name":"kz_mac",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=336084898",
+      "mapper_name":"mac",
+      "mapper_steamid64":"76561198056335207"
+   },
+   {
+      "id":"743",
+      "name":"kz_machinery",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1921655838",
+      "mapper_name":"iBUYFL0WER Birgit",
+      "mapper_steamid64":"76561198078014747"
+   },
+   {
+      "id":"406",
+      "name":"kz_magus",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=401088222",
+      "mapper_name":"Doveen",
+      "mapper_steamid64":"76561198033299991"
+   },
+   {
+      "id":"756",
+      "name":"kz_malignom_short",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1962044626",
+      "mapper_name":"jens",
+      "mapper_steamid64":"76561198110357840"
+   },
+   {
+      "id":"942",
+      "name":"kz_mandelbrot",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259048305",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"407",
+      "name":"kz_man_everest_go_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1098716930",
+      "mapper_name":"Kreedz, Spherix, GnagarN",
+      "mapper_steamid64":"76561197997103423, null, 76561198009902429"
+   },
+   {
+      "id":"408",
+      "name":"kz_marblewalls_fixed",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=391298485",
+      "mapper_name":"Aaron"
+   },
+   {
+      "id":"587",
+      "name":"kz_matilda_np",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1442293882",
+      "mapper_name":"Matilda",
+      "mapper_steamid64":"76561197999312081"
+   },
+   {
+      "id":"670",
+      "name":"kz_meander",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1657680583",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"410",
+      "name":"kz_megabhop_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667953480",
+      "mapper_name":"N1ghtFoX, Chuli"
+   },
+   {
+      "id":"411",
+      "name":"kz_megalodon",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1184142056",
+      "mapper_name":"nykaN",
+      "mapper_steamid64":"76561198014491259"
+   },
+   {
+      "id":"868",
+      "name":"kz_memento",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2226685570",
+      "mapper_name":"Downie2K",
+      "mapper_steamid64":"76561197981037626"
+   },
+   {
+      "id":"654",
+      "name":"kz_mescaline_f",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1704411752",
+      "mapper_name":"mark",
+      "mapper_steamid64":"76561198045869085"
+   },
+   {
+      "id":"412",
+      "name":"kz_metalrun_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406054781",
+      "mapper_name":"Witchhowl",
+      "mapper_steamid64":"76561198027343851"
+   },
+   {
+      "id":"903",
+      "name":"kz_micropenis",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2274722735",
+      "mapper_name":"Cou ",
+      "mapper_steamid64":"76561198007928944"
+   },
+   {
+      "id":"905",
+      "name":"kz_microwave",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259353310",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"824",
+      "name":"kz_mieszaneuczucia",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2168009794",
+      "mapper_name":"nutsdoodle",
+      "mapper_steamid64":"76561198150143219"
+   },
+   {
+      "id":"413",
+      "name":"kz_mike_v4",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352438024",
+      "mapper_name":"MikeChas",
+      "mapper_steamid64":"76561198033854242"
+   },
+   {
+      "id":"773",
+      "name":"kz_milehigh",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2081487108",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"414",
+      "name":"kz_minimalism",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=784686492",
+      "mapper_name":"badges, ρ",
+      "mapper_steamid64":"76561197983438223, 76561198002830622"
+   },
+   {
+      "id":"605",
+      "name":"kz_minimal_combo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688173479",
+      "mapper_name":"UNKNOWN:(",
+      "mapper_steamid64":"76561198140867695"
+   },
+   {
+      "id":"415",
+      "name":"kz_minimountain_f",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1819270715",
+      "mapper_name":"finckelton",
+      "mapper_steamid64":"76561198039388458"
+   },
+   {
+      "id":"588",
+      "name":"kz_modernvomit",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1387010348",
+      "mapper_name":"evanstep",
+      "mapper_steamid64":"76561198067339661"
+   },
+   {
+      "id":"416",
+      "name":"kz_module",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=531121171",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"417",
+      "name":"kz_moonlight",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=653958895",
+      "mapper_name":"jurkelis",
+      "mapper_steamid64":"76561198071655291"
+   },
+   {
+      "id":"625",
+      "name":"kz_moorerutan",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1538928192",
+      "mapper_name":"Rumme",
+      "mapper_steamid64":"76561198112936613"
+   },
+   {
+      "id":"418",
+      "name":"kz_morebricks_msq",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=624692501",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"571",
+      "name":"kz_morestairs_msq",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1370543054",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"807",
+      "name":"kz_motivated",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=504145143",
+      "mapper_name":"Drinka",
+      "mapper_steamid64":"76561198100929785"
+   },
+   {
+      "id":"419",
+      "name":"kz_msp_comatose",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418089472",
+      "mapper_name":"Pebi, masque, skitty",
+      "mapper_steamid64":"76561198077530872, 76561197979436335, 76561198031452487"
+   },
+   {
+      "id":"875",
+      "name":"kz_mushrruption_v8",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2280643029",
+      "mapper_name":"Sehk",
+      "mapper_steamid64":"76561198037724970"
+   },
+   {
+      "id":"744",
+      "name":"kz_mz",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1988044539",
+      "mapper_name":"Zach47, nykaN",
+      "mapper_steamid64":"76561197983014207, 76561198014491259"
+   },
+   {
+      "id":"784",
+      "name":"kz_nassau",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2096632231",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"420",
+      "name":"kz_natureblock_scte",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2111399696",
+      "mapper_name":"Chichin, Pr3da",
+      "mapper_steamid64":"76561197991555455, 76561198021246024"
+   },
+   {
+      "id":"421",
+      "name":"kz_nature_csgo",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080089",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"904",
+      "name":"kz_nb_final",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2246885072",
+      "mapper_name":"Da0lang",
+      "mapper_steamid64":"76561198814294487"
+   },
+   {
+      "id":"947",
+      "name":"kz_neoncity_z",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2260637520",
+      "mapper_name":"_Z",
+      "mapper_steamid64":"76561198365448333"
+   },
+   {
+      "id":"422",
+      "name":"kz_neon_portal",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=427001332",
+      "mapper_name":"TherapySession",
+      "mapper_steamid64":"76561198012265008"
+   },
+   {
+      "id":"802",
+      "name":"kz_nieh",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2128027875",
+      "mapper_name":"S1lic",
+      "mapper_steamid64":"76561198874435443"
+   },
+   {
+      "id":"810",
+      "name":"kz_nightcastle",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2143021601",
+      "mapper_name":"Petter",
+      "mapper_steamid64":"76561198416084167"
+   },
+   {
+      "id":"423",
+      "name":"kz_nightfall",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2073457452",
+      "mapper_name":"Pebi, Danvari",
+      "mapper_steamid64":"76561198077530872, 76561198038388449"
+   },
+   {
+      "id":"424",
+      "name":"kz_nightmare_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=386548794",
+      "mapper_name":"m-tet"
+   },
+   {
+      "id":"698",
+      "name":"kz_nix_od",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1773124335",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"809",
+      "name":"kz_noobfort",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2128202621",
+      "mapper_name":"Lux",
+      "mapper_steamid64":"76561198055771460"
+   },
+   {
+      "id":"940",
+      "name":"kz_northkorean_censorship",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2382813554",
+      "mapper_name":"rov",
+      "mapper_steamid64":"76561198132236283"
+   },
+   {
+      "id":"425",
+      "name":"kz_nyc_v1",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
+      "mapper_name":"Vypur",
+      "mapper_steamid64":"76561198027553039"
+   },
+   {
+      "id":"606",
+      "name":"kz_nymph",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
+      "mapper_name":"Cyclo",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"426",
+      "name":"kz_oasis",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=650371940",
+      "mapper_name":"Pebi",
+      "mapper_steamid64":"76561198077530872"
+   },
+   {
+      "id":"427",
+      "name":"kz_obsidian",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418449564",
+      "mapper_name":"SinFuL",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"723",
+      "name":"kz_okaychamp",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1881193335",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"428",
+      "name":"kz_oldstuff",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491404667",
+      "mapper_name":"DannyE",
+      "mapper_steamid64":"76561198178232629"
+   },
+   {
+      "id":"572",
+      "name":"kz_oloramasa",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1282978596",
+      "mapper_name":"Alves",
+      "mapper_steamid64":"76561198063573203"
+   },
+   {
+      "id":"429",
+      "name":"kz_olympus",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=171110248",
+      "mapper_name":"KingGambit",
+      "mapper_steamid64":"76561198023829871"
+   },
+   {
+      "id":"430",
+      "name":"kz_ominous2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=782868988",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"655",
+      "name":"kz_openspace",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1685172182",
+      "mapper_name":"Lazovsky",
+      "mapper_steamid64":"76561198003859123"
+   },
+   {
+      "id":"431",
+      "name":"kz_orangejuice_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=813837226",
+      "mapper_name":"masque, DanZay",
+      "mapper_steamid64":"76561197979436335, 76561197989817982"
+   },
+   {
+      "id":"432",
+      "name":"kz_orbolution_v2",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=644224500",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"795",
+      "name":"kz_otakuroom",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2106385628",
+      "mapper_name":"GemaYue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"433",
+      "name":"kz_overgrowth",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1092513702",
+      "mapper_name":"stz",
+      "mapper_steamid64":"76561198261992780"
+   },
+   {
+      "id":"626",
+      "name":"kz_overjoyed",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1465826915",
+      "mapper_name":"Gamzky",
+      "mapper_steamid64":"76561198262673963"
+   },
+   {
+      "id":"829",
+      "name":"kz_owtetad",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2190664967",
+      "mapper_name":"Krushed",
+      "mapper_steamid64":"76561197966948458"
+   },
+   {
+      "id":"724",
+      "name":"kz_p1",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1684028086",
+      "mapper_name":"JONY",
+      "mapper_steamid64":"76561198000829729"
+   },
+   {
+      "id":"676",
+      "name":"kz_paintball_tv_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1717536029",
+      "mapper_name":"pb, victoria248",
+      "mapper_steamid64":"76561197971221508, 76561198026839022"
+   },
+   {
+      "id":"774",
+      "name":"kz_pamxul_wip",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2085124881",
+      "mapper_name":"Lux",
+      "mapper_steamid64":"76561198055771460"
+   },
+   {
+      "id":"434",
+      "name":"kz_pantheism_p02",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519500089",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"435",
+      "name":"kz_paradise",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=636580309",
+      "mapper_name":"pr3da",
+      "mapper_steamid64":"76561198021246024"
+   },
+   {
+      "id":"436",
+      "name":"kz_peak_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419054557",
+      "mapper_name":"PHQ",
+      "mapper_steamid64":"76561197981825703"
+   },
+   {
+      "id":"934",
+      "name":"kz_pendulum",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1937590263",
+      "mapper_name":"JJ",
+      "mapper_steamid64":"76561198167125526"
+   },
+   {
+      "id":"931",
+      "name":"kz_perfunctory",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2253427267",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"437",
+      "name":"kz_phamous",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=404322417",
+      "mapper_name":"Phinx",
+      "mapper_steamid64":"76561198023207107"
+   },
+   {
+      "id":"438",
+      "name":"kz_pharaoh_csgo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=377402121",
+      "mapper_name":"Daniel_Lyness"
+   },
+   {
+      "id":"859",
+      "name":"kz_pharos_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2274441302",
+      "mapper_name":"Crixxzi",
+      "mapper_steamid64":"76561198046307458"
+   },
+   {
+      "id":"439",
+      "name":"kz_phaztec",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399418936",
+      "mapper_name":"Phinx",
+      "mapper_steamid64":"76561198023207107"
+   },
+   {
+      "id":"440",
+      "name":"kz_pianoclimb_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=230274161",
+      "mapper_name":"DyleT2"
+   },
+   {
+      "id":"441",
+      "name":"kz_pineforest_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=778556068",
+      "mapper_name":"Lillen",
+      "mapper_steamid64":"76561198077858937"
+   },
+   {
+      "id":"442",
+      "name":"kz_piranha",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1185869594",
+      "mapper_name":"GameChaos",
+      "mapper_steamid64":"76561198165203332"
+   },
+   {
+      "id":"443",
+      "name":"kz_pixelrun_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=782827606",
+      "mapper_name":"TheWhaleMan",
+      "mapper_steamid64":"76561198064508818"
+   },
+   {
+      "id":"444",
+      "name":"kz_plains",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=747076334",
+      "mapper_name":"Shire",
+      "mapper_steamid64":"76561198104341799"
+   },
+   {
+      "id":"445",
+      "name":"kz_pollution",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=633854360",
+      "mapper_name":"pr3da",
+      "mapper_steamid64":"76561198021246024"
+   },
+   {
+      "id":"656",
+      "name":"kz_porridge",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1533494110",
+      "mapper_name":"Diesel",
+      "mapper_steamid64":"76561198099241969"
+   },
+   {
+      "id":"806",
+      "name":"kz_portal_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2208043488",
+      "mapper_name":"epic",
+      "mapper_steamid64":"76561198028317188"
+   },
+   {
+      "id":"607",
+      "name":"kz_prekeeper",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1535314044",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"446",
+      "name":"kz_prima",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=896453952",
+      "mapper_name":"Cobrex",
+      "mapper_steamid64":"76561198060634245"
+   },
+   {
+      "id":"447",
+      "name":"kz_prismus",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080437",
+      "mapper_name":"Deepus",
+      "mapper_steamid64":"76561197976153012"
+   },
+   {
+      "id":"946",
+      "name":"kz_procrastination_f",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2370566385",
+      "mapper_name":"lenny",
+      "mapper_steamid64":"76561198145963095"
+   },
+   {
+      "id":"956",
+      "name":"kz_progressive",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2421910892",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"448",
+      "name":"kz_project",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=656536301",
+      "mapper_name":"Isk",
+      "mapper_steamid64":"76561198195095059"
+   },
+   {
+      "id":"782",
+      "name":"kz_prolific",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2091137824",
+      "mapper_name":"jord",
+      "mapper_steamid64":"76561198066952826"
+   },
+   {
+      "id":"608",
+      "name":"kz_prototype",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=520364028",
+      "mapper_name":"Smex",
+      "mapper_steamid64":"76561197961558198"
+   },
+   {
+      "id":"910",
+      "name":"kz_psychosomatic",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2422388657",
+      "mapper_name":"Plastyc, Raunox",
+      "mapper_steamid64":"76561199024218227, 76561198254175551"
+   },
+   {
+      "id":"790",
+      "name":"kz_psyk",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030706198",
+      "mapper_name":"G O A",
+      "mapper_steamid64":"76561197990887735"
+   },
+   {
+      "id":"449",
+      "name":"kz_psytime_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=623887144",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"745",
+      "name":"kz_purgatory",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1943903062",
+      "mapper_name":"Amber, htc, Rebmaa",
+      "mapper_steamid64":"null, null, 76561197970776455 "
+   },
+   {
+      "id":"450",
+      "name":"kz_quadrablock",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068013",
+      "mapper_name":"Pix"
+   },
+   {
+      "id":"451",
+      "name":"kz_quadrant_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1369715256",
+      "mapper_name":"River",
+      "mapper_steamid64":"76561198054436805"
+   },
+   {
+      "id":"452",
+      "name":"kz_quick7_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=562956061",
+      "mapper_name":"MurrayAU",
+      "mapper_steamid64":"76561198019551123"
+   },
+   {
+      "id":"620",
+      "name":"kz_quicksand",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1579335691",
+      "mapper_name":"Sisms(?)",
+      "mapper_steamid64":"76561198166999579"
+   },
+   {
+      "id":"453",
+      "name":"kz_quickshot",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=437195052",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"454",
+      "name":"kz_quixotic",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=581076797",
+      "mapper_name":"Matilda",
+      "mapper_steamid64":"76561197999312081"
+   },
+   {
+      "id":"455",
+      "name":"kz_railings",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=301219724",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"456",
+      "name":"kz_rainrun_kn_f",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509126081",
+      "mapper_name":"Knove",
+      "mapper_steamid64":"76561198109227174"
+   },
+   {
+      "id":"457",
+      "name":"kz_rcn_impermanence",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1235824121",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"458",
+      "name":"kz_rcn_optimisery",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1228153185",
+      "mapper_name":"archon",
+      "mapper_steamid64":"76561198034601835"
+   },
+   {
+      "id":"459",
+      "name":"kz_reach_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=421596934",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"813",
+      "name":"kz_rectangle",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2127477792",
+      "mapper_name":"Michael",
+      "mapper_steamid64":"76561198004229810"
+   },
+   {
+      "id":"460",
+      "name":"kz_redemption_csgo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=269756340",
+      "mapper_name":"Tipii, fl0w",
+      "mapper_steamid64":"null, 76561197991750093"
+   },
+   {
+      "id":"461",
+      "name":"kz_redline",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
+      "mapper_name":"ExtremerZ"
+      "mapper_steamid64":"76561197965479288"
+   },
+   {
+      "id":"764",
+      "name":"kz_refract",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2054929131",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"901",
+      "name":"kz_refuge",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2260756501",
+      "mapper_name":"nykaN",
+      "mapper_steamid64":"76561198014491259"
+   },
+   {
+      "id":"462",
+      "name":"kz_remedy_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=458847658",
+      "mapper_name":"Piu",
+      "mapper_steamid64":"76561198014009703"
+   },
+   {
+      "id":"688",
+      "name":"kz_research",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1233676255",
+      "mapper_name":"Fafnir",
+      "mapper_steamid64":"76561198072210646"
+   },
+   {
+      "id":"463",
+      "name":"kz_retribution_v2_final",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535037159",
+      "mapper_name":"Flux",
+      "mapper_steamid64":"76561198040691989"
+   },
+   {
+      "id":"464",
+      "name":"kz_return",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=610279618",
+      "mapper_name":"DanZay",
+      "mapper_steamid64":"76561197989817982"
+   },
+   {
+      "id":"899",
+      "name":"kz_reverse",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2261076218",
+      "mapper_name":"Temmie, Da0lang",
+      "mapper_steamid64":"76561198137502865, 76561198814294487"
+   },
+   {
+      "id":"628",
+      "name":"kz_rise",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=661509726",
+      "mapper_name":"schm0ftie",
+      "mapper_steamid64":"76561197983561860"
+   },
+   {
+      "id":"465",
+      "name":"kz_rockclimb",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=294354248",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"466",
+      "name":"kz_rockjungle_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=706798826",
+      "mapper_name":"GWB",
+      "mapper_steamid64":"76561198010817168"
+   },
+   {
+      "id":"467",
+      "name":"kz_rocks_global",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1728344964",
+      "mapper_name":"keyuu",
+      "mapper_steamid64":"76561198003202977"
+   },
+   {
+      "id":"765",
+      "name":"kz_roman",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2071759440",
+      "mapper_name":"Ori",
+      "mapper_steamid64":"76561198157565655"
+   },
+   {
+      "id":"874",
+      "name":"kz_rompenutrias_asheglado",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1528890944",
+      "mapper_name":"Shendal",
+      "mapper_steamid64":"76561198225775664"
+   },
+   {
+      "id":"555",
+      "name":"kz_rumzor",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1157701765",
+      "mapper_name":"Rumme",
+      "mapper_steamid64":"76561198112936613"
+   },
+   {
+      "id":"852",
+      "name":"kz_rush2sk8",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2212481749",
+      "mapper_name":"rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"919",
+      "name":"kz_rush2suck",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2346899830",
+      "mapper_name":"Krushed, stz, nopey",
+      "mapper_steamid64":"76561197966948458, 76561198261992780, 76561198401447544"
+   },
+   {
+      "id":"468",
+      "name":"kz_sanctuary",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387095066",
+      "mapper_name":"Ace"
+   },
+   {
+      "id":"469",
+      "name":"kz_sandstone_mq",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=318255698",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"470",
+      "name":"kz_sandstorm_ez",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399829430",
+      "mapper_name":"DropInMilk",
+      "mapper_steamid64":"76561198033385282"
+   },
+   {
+      "id":"471",
+      "name":"kz_sandyhill_hoc",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068273",
+      "mapper_name":"SinFuL",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"886",
+      "name":"kz_scum",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2262738254",
+      "mapper_name":"dillon",
+      "mapper_steamid64":"76561198120868833"
+   },
+   {
+      "id":"472",
+      "name":"kz_sendhelp_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414276208",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"473",
+      "name":"kz_serenity",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=564068433",
+      "mapper_name":"UnderhellCS",
+      "mapper_steamid64":"76561198071769233"
+   },
+   {
+      "id":"877",
+      "name":"kz_shaft_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228832434",
+      "mapper_name":"Beikenost",
+      "mapper_steamid64":"76561198117002699"
+   },
+   {
+      "id":"671",
+      "name":"kz_shell",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1640657838",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"766",
+      "name":"kz_shortcut_tx",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2059971679",
+      "mapper_name":"Elem",
+      "mapper_steamid64":"76561199023877609"
+   },
+   {
+      "id":"475",
+      "name":"kz_signs_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=570362293",
+      "mapper_name":"Guta",
+      "mapper_steamid64":"76561198000799482"
+   },
+   {
+      "id":"726",
+      "name":"kz_simplejourney",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1842969271",
+      "mapper_name":"ρ",
+      "mapper_steamid64":"76561198002830622"
+   },
+   {
+      "id":"725",
+      "name":"kz_simple_sp",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1995891136",
+      "mapper_name":"saicho91",
+      "mapper_steamid64":"76561197995141366"
+   },
+   {
+      "id":"476",
+      "name":"kz_simplicity_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=596881274",
+      "mapper_name":"Netcode",
+      "mapper_steamid64":"76561198083399596"
+   },
+   {
+      "id":"836",
+      "name":"kz_skybridge",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2170006392",
+      "mapper_name":"Aquilla",
+      "mapper_steamid64":"76561198337861414"
+   },
+   {
+      "id":"477",
+      "name":"kz_skyhotel",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=508852626",
+      "mapper_name":"Flux",
+      "mapper_steamid64":"76561198040691989"
+   },
+   {
+      "id":"556",
+      "name":"kz_sky_lake",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1298788457",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"479",
+      "name":"kz_slate",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=871544753",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"702",
+      "name":"kz_slidebober",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1825259311",
+      "mapper_name":"Slyph"
+   },
+   {
+      "id":"746",
+      "name":"kz_slidemap_ez_v2_rmk_final",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2421819231",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"949",
+      "name":"kz_slide_concrete",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2356803567",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"775",
+      "name":"kz_slide_deee",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2016401059",
+      "mapper_name":"Dima",
+      "mapper_steamid64":"76561198198062889"
+   },
+   {
+      "id":"632",
+      "name":"kz_slide_dydanhomon",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1586833508",
+      "mapper_name":"dydka",
+      "mapper_steamid64":"76561198010747369"
+   },
+   {
+      "id":"797",
+      "name":"kz_slide_kissa",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2081916777",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"757",
+      "name":"kz_slide_koira",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2010190400",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"909",
+      "name":"kz_slide_pallokala",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2288332530",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"890",
+      "name":"kz_slide_pisauva",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2251257791",
+      "mapper_name":"Shendal",
+      "mapper_steamid64":"76561198225775664"
+   },
+   {
+      "id":"703",
+      "name":"kz_slide_purple_x",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1842176999",
+      "mapper_name":"Kirman, PreFect"
+   },
+   {
+      "id":"945",
+      "name":"kz_slide_rawr_xdeee",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2190416060",
+      "mapper_name":"Dima",
+      "mapper_steamid64":"76561198198062889"
+   },
+   {
+      "id":"727",
+      "name":"kz_slide_rovod",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2418190102",
+      "mapper_name":"rov, Overdose",
+      "mapper_steamid64":"76561198132236283, 76561198142809343"
+   },
+   {
+      "id":"609",
+      "name":"kz_slide_svn_extreme",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1545821165",
+      "mapper_name":"SilverNinja"
+   },
+   {
+      "id":"704",
+      "name":"kz_slide_svn_temple",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1866612534",
+      "mapper_name":"SilverNinja"
+   },
+   {
+      "id":"821",
+      "name":"kz_slide_vaahtera",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2184236748",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"818",
+      "name":"kz_slowrun_global_fix",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1355920261",
+      "mapper_name":"cnc3ep1",
+      "mapper_steamid64":"76561198143741877"
+   },
+   {
+      "id":"672",
+      "name":"kz_slumpfrageous",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1741709684",
+      "mapper_name":"victoria248",
+      "mapper_steamid64":"76561198026839022"
+   },
+   {
+      "id":"789",
+      "name":"kz_smallcastle",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2025955407",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"573",
+      "name":"kz_smallmap",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1339159026",
+      "mapper_name":"Samuel",
+      "mapper_steamid64":"76561198191875674"
+   },
+   {
+      "id":"480",
+      "name":"kz_snowman_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=337956674",
+      "mapper_name":"DutchSnowman",
+      "mapper_steamid64":"76561198027507070"
+   },
+   {
+      "id":"481",
+      "name":"kz_solidarity_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580922647",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"955",
+      "name":"kz_sonder",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2385596806",
+      "mapper_name":"dillon",
+      "mapper_steamid64":"76561198120868833"
+   },
+   {
+      "id":"853",
+      "name":"kz_sp1_bloodyljs",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224266412",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"880",
+      "name":"kz_sp1_candles",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2243496277",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"912",
+      "name":"kz_sp1_castaway",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2283294555",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"935",
+      "name":"kz_sp1_hallwaybhop",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2305555371",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"854",
+      "name":"kz_sp1_hiragana",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2210394074",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"948",
+      "name":"kz_sp1_katakana",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381711985",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"927",
+      "name":"kz_sp1_perf2win",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2322149205",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"861",
+      "name":"kz_spaceladders_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2229077733",
+      "mapper_name":"Cybur",
+      "mapper_steamid64":"76561198062384407"
+   },
+   {
+      "id":"557",
+      "name":"kz_spacemario_h",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685184665",
+      "mapper_name":"Eightb0",
+      "mapper_steamid64":"76561198010762038"
+   },
+   {
+      "id":"482",
+      "name":"kz_spacus",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=522846216",
+      "mapper_name":"Deepus, Hawk",
+      "mapper_steamid64":"76561197976153012, 76561198218057127"
+   },
+   {
+      "id":"846",
+      "name":"kz_spire",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2205432051",
+      "mapper_name":"RZL, Fnugz",
+      "mapper_steamid64":"76561197985774978, 76561198012891563"
+   },
+   {
+      "id":"483",
+      "name":"kz_spiritblockv2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068550",
+      "mapper_name":"jYue, SoUlFaThEr",
+      "mapper_steamid64":"null, 76561197965266419"
+   },
+   {
+      "id":"812",
+      "name":"kz_splopkopsc_loverick",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1126798978",
+      "mapper_name":"Steez",
+      "mapper_steamid64":"76561198261992780"
+   },
+   {
+      "id":"484",
+      "name":"kz_spores_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418447771",
+      "mapper_name":"G O A",
+      "mapper_steamid64":"76561197990887735"
+   },
+   {
+      "id":"485",
+      "name":"kz_sqrdsucks",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=870091342",
+      "mapper_name":"Krushed",
+      "mapper_steamid64":"76561197966948458"
+   },
+   {
+      "id":"855",
+      "name":"kz_stepblock",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2221286065",
+      "mapper_name":"Crixxzi",
+      "mapper_steamid64":"76561198046307458"
+   },
+   {
+      "id":"954",
+      "name":"kz_stepup",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2378820376",
+      "mapper_name":"Emzatin",
+      "mapper_steamid64":"76561198393292046"
+   },
+   {
+      "id":"486",
+      "name":"kz_strafehop_fix",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=727970399",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"487",
+      "name":"kz_stranded",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=881021394",
+      "mapper_name":"nykaN, coach",
+      "mapper_steamid64":"76561198014491259, 76561197969061501"
+   },
+   {
+      "id":"488",
+      "name":"kz_streetblock_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
+      "mapper_name":"s0lid"
+      "mapper_steamid64":"76561197980460370"
+   },
+   {
+      "id":"856",
+      "name":"kz_structures",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=613750240",
+      "mapper_name":"colony",
+      "mapper_steamid64":"76561198012716104"
+   },
+   {
+      "id":"489",
+      "name":"kz_strun_mq",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=522194087",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"490",
+      "name":"kz_stuff_final",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=397542914",
+      "mapper_name":"Pebi",
+      "mapper_steamid64":"76561198077530872"
+   },
+   {
+      "id":"491",
+      "name":"kz_sukblock_v2_fixed",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=511719435",
+      "mapper_name":"Suck' TearZ"
+   },
+   {
+      "id":"492",
+      "name":"kz_summercliff2_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
+      "mapper_name":"s0liD"
+      "mapper_steamid64":"76561197980460370"
+   },
+   {
+      "id":"776",
+      "name":"kz_suomi",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030976502",
+      "mapper_name":"tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"915",
+      "name":"kz_superstructure",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2252104070",
+      "mapper_name":"_max",
+      "mapper_steamid64":"76561198083065598"
+   },
+   {
+      "id":"944",
+      "name":"kz_surf_ace",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2366218120",
+      "mapper_name":"Dima, Juxtapo",
+      "mapper_steamid64":"76561198198062889, 76561197982874432"
+   },
+   {
+      "id":"705",
+      "name":"kz_surf_blue",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1777661554",
+      "mapper_name":"CyclO",
+      "mapper_steamid64":"76561198024466262"
+   },
+   {
+      "id":"494",
+      "name":"kz_surf_kim_hana_gl",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=846934364",
+      "mapper_name":"Gull",
+      "mapper_steamid64":"76561198137589262"
+   },
+   {
+      "id":"495",
+      "name":"kz_swamped_v3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=737262158",
+      "mapper_name":"Orbit",
+      "mapper_steamid64":"76561198057269402"
+   },
+   {
+      "id":"496",
+      "name":"kz_symbiosis_final",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=407752167",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"835",
+      "name":"kz_symmetry",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2169425331",
+      "mapper_name":"Lameskydiver",
+      "mapper_steamid64":"76561198082880577"
+   },
+   {
+      "id":"219",
+      "name":"kz_synergy_ez",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030361679",
+      "mapper_name":"pLANE, fl0w",
+      "mapper_steamid64":"76561197969425557, 76561197991750093"
+   },
+   {
+      "id":"220",
+      "name":"kz_synergy_x",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030360282",
+      "mapper_name":"pLANE, fl0w",
+      "mapper_steamid64":"76561197969425557, 76561197991750093"
+   },
+   {
+      "id":"497",
+      "name":"kz_synthesis_v2",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=524273901",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"498",
+      "name":"kz_sz_goldenbean",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279111456",
+      "mapper_name":"SinFuL",
+      "mapper_steamid64":"76561197970838363"
+   },
+   {
+      "id":"500",
+      "name":"kz_talltreeforest_v3",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=353767057",
+      "mapper_name":"Vypur",
+      "mapper_steamid64":"76561198027553039"
+   },
+   {
+      "id":"501",
+      "name":"kz_talmaniac",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=875664112",
+      "mapper_name":"AREDONE, GameChaos",
+      "mapper_steamid64":"76561198082306844, 76561198165203332"
+   },
+   {
+      "id":"857",
+      "name":"kz_technical_difficulties",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215677224",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"637",
+      "name":"kz_techtonic_v2_ldr",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1679345238",
+      "mapper_name":"iBUYFL0WER Birgit",
+      "mapper_steamid64":"76561198078014747"
+   },
+   {
+      "id":"502",
+      "name":"kz_terablock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=269563440",
+      "mapper_name":"SinFul, fl0w",
+      "mapper_steamid64":"null, 76561197991750093"
+   },
+   {
+      "id":"816",
+      "name":"kz_theaquila",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2183036742",
+      "mapper_name":"Aquilla",
+      "mapper_steamid64":"76561198337861414"
+   },
+   {
+      "id":"610",
+      "name":"kz_thinkblock",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1543810415",
+      "mapper_name":"xq, GameChaos",
+      "mapper_steamid64":"76561198094382485, 76561198165203332"
+   },
+   {
+      "id":"748",
+      "name":"kz_thrombosis",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1803151428",
+      "mapper_name":"rov",
+      "mapper_steamid64":"76561198132236283"
+   },
+   {
+      "id":"503",
+      "name":"kz_timescape_zero",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=937263331",
+      "mapper_name":"Blixx",
+      "mapper_steamid64":"76561198017413484"
+   },
+   {
+      "id":"504",
+      "name":"kz_tomb_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1099232235",
+      "mapper_name":"MoHaX_cm"
+   },
+   {
+      "id":"505",
+      "name":"kz_toonadventure_go",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068846",
+      "mapper_name":"PHQ",
+      "mapper_steamid64":"76561197981825703"
+   },
+   {
+      "id":"506",
+      "name":"kz_toonrun_final",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=375234842",
+      "mapper_name":"BigBangQuint"
+   },
+   {
+      "id":"673",
+      "name":"kz_toughluck_fix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1740708159",
+      "mapper_name":"TurboAgent"
+   },
+   {
+      "id":"508",
+      "name":"kz_tour_de_nuke_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055304",
+      "mapper_name":"bacUp",
+      "mapper_steamid64":"76561197992737822"
+   },
+   {
+      "id":"509",
+      "name":"kz_tradeblock_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352763435",
+      "mapper_name":"Millet"
+   },
+   {
+      "id":"510",
+      "name":"kz_trashsurf",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419954977",
+      "mapper_name":"ticK!",
+      "mapper_steamid64":"76561198171545305"
+   },
+   {
+      "id":"783",
+      "name":"kz_trazodon_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2167786919",
+      "mapper_name":"Zeldox",
+      "mapper_steamid64":"76561197965379945"
+   },
+   {
+      "id":"511",
+      "name":"kz_tribute",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=771511732",
+      "mapper_name":"darksy",
+      "mapper_steamid64":"76561197985961109"
+   },
+   {
+      "id":"512",
+      "name":"kz_tron_global",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055395"
+   },
+   {
+      "id":"677",
+      "name":"kz_twiivo",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1755261291",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198094382485"
+   },
+   {
+      "id":"493",
+      "name":"kz_twilight_od",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1885058481",
+      "mapper_name":"Overdose",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"787",
+      "name":"kz_twister",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2104121795",
+      "mapper_name":"Fksch",
+      "mapper_steamid64":"76561198142682783"
+   },
+   {
+      "id":"893",
+      "name":"kz_unity_collab",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=864605202",
+      "mapper_name":"G O A, Magical, ρ",
+      "mapper_steamid64":"76561197990887735, 76561197994466910, 76561198002830622"
+   },
+   {
+      "id":"513",
+      "name":"kz_unity_u01",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519498299",
+      "mapper_name":"zPrince",
+      "mapper_steamid64":"76561198047032125"
+   },
+   {
+      "id":"690",
+      "name":"kz_unknownspace",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1738660683",
+      "mapper_name":"mjb",
+      "mapper_steamid64":"76561198093921774"
+   },
+   {
+      "id":"865",
+      "name":"kz_unmake",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2201592299",
+      "mapper_name":"Chichin",
+      "mapper_steamid64":"76561197991555455"
+   },
+   {
+      "id":"878",
+      "name":"kz_variety_fix",
+      "difficulty":"4",
+      "workshop_url":" https://steamcommunity.com/sharedfiles/filedetails/?id=2251584934",
+      "mapper_name":"Emzatin",
+      "mapper_steamid64":"76561198393292046"
+   },
+   {
+      "id":"514",
+      "name":"kz_vci_apprentice",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685276922",
+      "mapper_name":"VCi",
+      "mapper_steamid64":"76561198177716323"
+   },
+   {
+      "id":"515",
+      "name":"kz_verv3_gg",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=568150287",
+      "mapper_name":"Greg",
+      "mapper_steamid64":"76561198029772319"
+   },
+   {
+      "id":"630",
+      "name":"kz_village",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1613996676",
+      "mapper_name":"biql, GameChaos",
+      "mapper_steamid64":"76561198146445979, 76561198165203332"
+   },
+   {
+      "id":"516",
+      "name":"kz_violet_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=603787190",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"674",
+      "name":"kz_vittu_mika_persse",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1735347577",
+      "mapper_name":"victoria248",
+      "mapper_steamid64":"76561198026839022"
+   },
+   {
+      "id":"517",
+      "name":"kz_void",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=789833143",
+      "mapper_name":"finckelton",
+      "mapper_steamid64":"76561198039388458"
+   },
+   {
+      "id":"518",
+      "name":"kz_warehouse",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=288587982",
+      "mapper_name":"Witchhowl",
+      "mapper_steamid64":"76561198027343851"
+   },
+   {
+      "id":"657",
+      "name":"kz_waterhole",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1656359071",
+      "mapper_name":"lazovsky"
+   },
+   {
+      "id":"777",
+      "name":"kz_weebfactory_censored",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2110341385",
+      "mapper_name":"mark",
+      "mapper_steamid64":"76561198045869085"
+   },
+   {
+      "id":"611",
+      "name":"kz_wetbricks",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1341015034",
+      "mapper_name":"Random Eye",
+      "mapper_steamid64":"76561197987069371"
+   },
+   {
+      "id":"519",
+      "name":"kz_whatever_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=439146522",
+      "mapper_name":"GemaYue",
+      "mapper_steamid64":"76561198019909186"
+   },
+   {
+      "id":"678",
+      "name":"kz_why",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1773239409",
+      "mapper_name":"archon, Overdose",
+      "mapper_steamid64":"76561198034601835, 76561198142809343"
+   },
+   {
+      "id":"520",
+      "name":"kz_woodstock_v2",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=620160091",
+      "mapper_name":"pr3da",
+      "mapper_steamid64":"76561198021246024"
+   },
+   {
+      "id":"521",
+      "name":"kz_woodstonegrass_final",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=594369922",
+      "mapper_name":"MurrayAU",
+      "mapper_steamid64":"76561198019551123"
+   },
+   {
+      "id":"522",
+      "name":"kz_woodworld",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=306647639",
+      "mapper_name":"masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"523",
+      "name":"kz_xand",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387908744",
+      "mapper_name":"a$ce"
+   },
+   {
+      "id":"615",
+      "name":"kz_xmas2008",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118382",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"616",
+      "name":"kz_xmas2009",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118842",
+      "mapper_name":"FoF, ρ",
+      "mapper_steamid64":"76561197991832101, 76561198002830622"
+   },
+   {
+      "id":"907",
+      "name":"kz_xmas2020",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224396057",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"524",
+      "name":"kz_xtremeblock_v2",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156069128",
+      "mapper_name":"Chrizzy"
+   },
+   {
+      "id":"574",
+      "name":"kz_yoink",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1308906365",
+      "mapper_name":"bainz, GameChaos",
+      "mapper_steamid64":"76561198183817078, 76561198165203332"
+   },
+   {
+      "id":"822",
+      "name":"kz_zaloopazxc",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1918571009",
+      "mapper_name":"downeel",
+      "mapper_steamid64":"76561198160259346"
+   },
+   {
+      "id":"525",
+      "name":"kz_za_tileblock",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080925",
+      "mapper_name":"Masque",
+      "mapper_steamid64":"76561197979436335"
+   },
+   {
+      "id":"526",
+      "name":"kz_zhop_freestyle",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685863435",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"527",
+      "name":"kz_zhop_function3",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=606199162",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"528",
+      "name":"kz_zhop_son_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580178806",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"529",
+      "name":"kz_ziggurath_final",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=684097443",
+      "mapper_name":"burny",
+      "mapper_steamid64":"76561197989457424"
+   },
+   {
+      "id":"729",
+      "name":"kz_zoomer_fix",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996270299",
+      "mapper_name":"CoD",
+      "mapper_steamid64":"76561198846255522"
+   },
+   {
+      "id":"530",
+      "name":"kz_zxp_final4",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=632673660",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"645",
+      "name":"kz_zxp_interstellar_v2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667954510",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"531",
+      "name":"kz_zxp_undia",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=639874816",
+      "mapper_name":"Zprince",
+      "mapper_steamid64":"76561198151858167"
+   },
+   {
+      "id":"612",
+      "name":"skz_bananaysoda_2",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1200744110",
+      "mapper_name":"Jony",
+      "mapper_steamid64":"76561198000829729"
+   },
+   {
+      "id":"589",
+      "name":"skz_makalaka",
+      "difficulty":"7",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1340859713",
+      "mapper_name":"Gamechaos",
+      "mapper_steamid64":"76561198165203332"
+   },
+   {
+      "id":"869",
+      "name":"skz_map",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2257677246",
+      "mapper_name":"Rush2sk8",
+      "mapper_steamid64":"76561198082904691"
+   },
+   {
+      "id":"640",
+      "name":"skz_odious_v2",
+      "difficulty":"6",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2001125206",
+      "mapper_name":"xq, Danvari",
+      "mapper_steamid64":"76561198094382485, 76561198038388449"
+   },
+   {
+      "id":"558",
+      "name":"skz_sati",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1226660943",
+      "mapper_name":"xq",
+      "mapper_steamid64":"76561198142809343"
+   },
+   {
+      "id":"891",
+      "name":"skz_sequence_shot",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2263251231",
+      "mapper_name":"lenny",
+      "mapper_steamid64":"76561198145963095"
+   },
+   {
+      "id":"633",
+      "name":"vnl_cat",
+      "difficulty":"4",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1594689613",
+      "mapper_name":"Schrødna",
+      "mapper_steamid64":"76561198067192262"
+   },
+   {
+      "id":"837",
+      "name":"vnl_invasion",
+      "difficulty":"5",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2027995295",
+      "mapper_name":"Birgit",
+      "mapper_steamid64":"76561198078014747"
+   },
+   {
+      "id":"841",
+      "name":"vnl_whiterun",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2209883717",
+      "mapper_name":"Spider1",
+      "mapper_steamid64":"76561198042146961"
+   },
+   {
+      "id":"778",
+      "name":"xc_alt_nephilim",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2072370967",
+      "mapper_name":"G O A",
+      "mapper_steamid64":"76561197990887735"
+   },
+   {
+      "id":"858",
+      "name":"xc_cliffjump_fix",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215515724",
+      "mapper_name":"Tatska",
+      "mapper_steamid64":"76561198433558585"
+   },
+   {
+      "id":"596",
+      "name":"xc_dreamland2",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1287723058",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"559",
+      "name":"xc_dtt_nasty_go",
+      "difficulty":"1",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1257230741",
+      "mapper_name":"Dogers, ρ",
+      "mapper_steamid64":"null, 76561198002830622"
+   },
+   {
+      "id":"560",
+      "name":"xc_fox_shrine_japan_fr",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1279693156",
+      "mapper_name":"incAming"
+   },
+   {
+      "id":"532",
+      "name":"xc_karo4",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1193986481",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"533",
+      "name":"xc_lucid_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406056737",
+      "mapper_name":"G O A",
+      "mapper_steamid64":"76561197990887735"
+   },
+   {
+      "id":"534",
+      "name":"xc_minecraft2_global",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419053494",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"535",
+      "name":"xc_minecraft3_global",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406057063",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"758",
+      "name":"xc_minecraft4",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2025541839",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   },
+   {
+      "id":"536",
+      "name":"xc_nephilim",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
+      "mapper_name":"G O A"
+      "mapper_steamid64":"76561197990887735"
+   },
+   {
+      "id":"537",
+      "name":"xc_powerblock_rc1",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156206701",
+      "mapper_name":"RZL",
+      "mapper_steamid64":"76561197985774978"
+   },
+   {
+      "id":"538",
+      "name":"xc_secret_valley_global_fix",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=451014834",
+      "mapper_name":"Sodan Tok"
+   },
+   {
+      "id":"539",
+      "name":"xc_skycastle",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1660023848",
+      "mapper_name":"Bendix, victoria248",
+      "mapper_steamid64":"null, 76561198026839022"
+   },
+   {
+      "id":"540",
+      "name":"xc_supermario_go_gfix",
+      "difficulty":"2",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939578036",
+      "mapper_name":"Disturbed, Iconic"
+   },
+   {
+      "id":"541",
+      "name":"xc_umbrella_global",
+      "difficulty":"3",
+      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419054050",
+      "mapper_name":"ProAqua",
+      "mapper_steamid64":"76561198051496034"
+   }
 ]

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -415,7 +415,8 @@
       "name":"kz_agility_v2_fix",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=392863247",
-      "mapper_name":"Aaron"
+      "mapper_name":"Aaron",
+      "mapper_steamid64":"76561198036059696"
    },
    {
       "id":"235",
@@ -4024,7 +4025,8 @@
       "name":"kz_quadrablock",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068013",
-      "mapper_name":"Pix"
+      "mapper_name":"Pix, SinFuL",
+      "mapper_steamid64":"null, 76561197970838363"
    },
    {
       "id":"451",

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -12,7 +12,7 @@
       "name":"bkz_blackrockshooter_vzp",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
-      "mapper_name":"Reborn"
+      "mapper_name":"Reborn",
       "mapper_steamid64":"76561197992700411"
    },
    {
@@ -52,7 +52,7 @@
       "name":"bkz_caves_go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
-      "mapper_name":"pAtq"
+      "mapper_name":"pAtq",
       "mapper_steamid64":"76561197997468889"
    },
    {
@@ -67,7 +67,7 @@
       "name":"bkz_chillhop_go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
-      "mapper_name":"FoF"
+      "mapper_name":"FoF",
       "mapper_steamid64":"76561197991832101"
    },
    {
@@ -176,7 +176,7 @@
       "name":"bkz_measure",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
-      "mapper_name":"ExtremerZ"
+      "mapper_name":"ExtremerZ",
       "mapper_steamid64":"76561197965479288"
    },
    {
@@ -184,7 +184,7 @@
       "name":"bkz_measure2_b03",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
-      "mapper_name":"ExtremerZ"
+      "mapper_name":"ExtremerZ",
       "mapper_steamid64":"76561197965479288"
    },
    {
@@ -192,7 +192,7 @@
       "name":"bkz_nocturns_blue_gfix",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
-      "mapper_name":"Levite"
+      "mapper_name":"Levite",
       "mapper_steamid64":"76561198031166668"
    },
    {
@@ -865,7 +865,7 @@
       "name":"kz_bhop_essence",
       "difficulty":"4",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
-      "mapper_name":"vay"
+      "mapper_name":"vay",
       "mapper_steamid64":"76561198131632059"
    },
    {
@@ -1208,7 +1208,7 @@
       "name":"kz_cartooncastle_go",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
-      "mapper_name":"s0liD, karatekafer"
+      "mapper_name":"s0liD, karatekafer",
       "mapper_steamid64":"76561197980460370, null"
    },
    {
@@ -2365,7 +2365,7 @@
       "name":"kz_genesis_go2",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
-      "mapper_name":"FoF"
+      "mapper_name":"FoF",
       "mapper_steamid64":"76561197991832101"
    },
    {
@@ -2684,7 +2684,7 @@
       "name":"kz_hillside",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
-      "mapper_name":"s0liD"
+      "mapper_name":"s0liD",
       "mapper_steamid64":"76561197980460370"
    },
    {
@@ -2812,7 +2812,7 @@
       "name":"kz_j2s_cupblock_go_fix2",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
-      "mapper_name":"s0lid, Spherix"
+      "mapper_name":"s0lid, Spherix",
       "mapper_steamid64":"76561197980460370, null"
    },
    {
@@ -3211,7 +3211,7 @@
       "name":"kz_longjumps_easy",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
-      "mapper_name":"ExtremerZ"
+      "mapper_name":"ExtremerZ",
       "mapper_steamid64":"76561197965479288"
    },
    {
@@ -4117,7 +4117,7 @@
       "name":"kz_redline",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
-      "mapper_name":"ExtremerZ"
+      "mapper_name":"ExtremerZ",
       "mapper_steamid64":"76561197965479288"
    },
    {
@@ -4720,7 +4720,7 @@
       "name":"kz_streetblock_go",
       "difficulty":"2",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
-      "mapper_name":"s0lid"
+      "mapper_name":"s0lid",
       "mapper_steamid64":"76561197980460370"
    },
    {
@@ -4759,7 +4759,7 @@
       "name":"kz_summercliff2_go",
       "difficulty":"1",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
-      "mapper_name":"s0liD"
+      "mapper_name":"s0liD",
       "mapper_steamid64":"76561197980460370"
    },
    {
@@ -5469,7 +5469,7 @@
       "name":"xc_nephilim",
       "difficulty":"3",
       "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
-      "mapper_name":"G O A"
+      "mapper_name":"G O A",
       "mapper_steamid64":"76561197990887735"
    },
    {

--- a/MapsWithMappers.json
+++ b/MapsWithMappers.json
@@ -1,5513 +1,5512 @@
-[
-   {
-      "id":"200",
-      "name":"bkz_apricity_v3",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1986459033",
-      "mapper_name":"Badges",
-      "mapper_steamid64":"76561197983438223"
-   },
-   {
-      "id":"201",
-      "name":"bkz_blackrockshooter_vzp",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
-      "mapper_name":"Reborn"
-      "mapper_steamid64":"76561197992700411"
-   },
-   {
-      "id":"202",
-      "name":"bkz_bonus_z1",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509297499",
-      "mapper_name":"ZPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"269",
-      "name":"bkz_cakewalk",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1613453363",
-      "mapper_name":"zPrince, GameChaos",
-      "mapper_steamid64":"76561198047032125, 76561198165203332"
-   },
-   {
-      "id":"203",
-      "name":"bkz_cauz_final",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535665232",
-      "mapper_name":"Cau",
-      "mapper_steamid64":"76561198041208499"
-   },
-   {
-      "id":"204",
-      "name":"bkz_cauz_short",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535645053",
-      "mapper_name":"Cau",
-      "mapper_steamid64":"76561198041208499"
-   },
-   {
-      "id":"205",
-      "name":"bkz_caves_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
-      "mapper_name":"pAtq"
-      "mapper_steamid64":"76561197997468889"
-   },
-   {
-      "id":"206",
-      "name":"bkz_cg_coldbhop",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=346170878",
-      "mapper_name":"DaMp"
-   },
-   {
-      "id":"207",
-      "name":"bkz_chillhop_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
-      "mapper_name":"FoF"
-      "mapper_steamid64":"76561197991832101"
-   },
-   {
-      "id":"597",
-      "name":"bkz_dontstop",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=449657758",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"208",
-      "name":"bkz_dydhop",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=784515943",
-      "mapper_name":"dydka",
-      "mapper_steamid64":"76561198010747369"
-   },
-   {
-      "id":"209",
-      "name":"bkz_evanstep",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=842652467",
-      "mapper_name":"Evanstep",
-      "mapper_steamid64":"76561198067339661"
-   },
-   {
-      "id":"551",
-      "name":"bkz_fapzor",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1304605829",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"542",
-      "name":"bkz_fear4",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1251914494",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
-   },
-   {
-      "id":"210",
-      "name":"bkz_goldbhop_csgo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=245286254",
-      "mapper_name":"Sprite"
-   },
-   {
-      "id":"211",
-      "name":"bkz_goldbhop_v2go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=343824673",
-      "mapper_name":"Sprite"
-   },
-   {
-      "id":"212",
-      "name":"bkz_hellokitty_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688361403",
-      "mapper_name":"Kore"
-   },
-   {
-      "id":"213",
-      "name":"bkz_impulse",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418436480",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"661",
-      "name":"bkz_iota_v3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1734579951",
-      "mapper_name":"_Max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"767",
-      "name":"bkz_itz_h25l",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2076525905",
-      "mapper_name":"iTz",
-      "mapper_steamid64":"76561198104765796"
-   },
-   {
-      "id":"214",
-      "name":"bkz_levite_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667950111",
-      "mapper_name":"Levite",
-      "mapper_steamid64":"76561198031166668"
-   },
-   {
-      "id":"707",
-      "name":"bkz_lewlysex",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1904095585",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"215",
-      "name":"bkz_measure",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
-      "mapper_name":"ExtremerZ"
-      "mapper_steamid64":"76561197965479288"
-   },
-   {
-      "id":"216",
-      "name":"bkz_measure2_b03",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
-      "mapper_name":"ExtremerZ"
-      "mapper_steamid64":"76561197965479288"
-   },
-   {
-      "id":"217",
-      "name":"bkz_nocturns_blue_gfix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
-      "mapper_name":"Levite"
-      "mapper_steamid64":"76561198031166668"
-   },
-   {
-      "id":"827",
-      "name":"bkz_pogo",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2136367398",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"218",
-      "name":"bkz_sahara",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1840329522",
-      "mapper_name":"noko, GameChaos",
-      "mapper_steamid64":"76561198013202660, 76561198165203332"
-   },
-   {
-      "id":"221",
-      "name":"bkz_underground_crypt_v3",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491359928",
-      "mapper_name":"Yaznee"
-   },
-   {
-      "id":"222",
-      "name":"bkz_uninspired_trash",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053096",
-      "mapper_name":"Felicienne"
-   },
-   {
-      "id":"223",
-      "name":"bkz_volcanohop",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=868101976",
-      "mapper_name":"Sprite"
-   },
-   {
-      "id":"820",
-      "name":"bkz_zephyr_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2173494916",
-      "mapper_name":"crixzzi",
-      "mapper_steamid64":"76561198046307458"
-   },
-   {
-      "id":"224",
-      "name":"kzpro_concrete_c02",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519499196",
-      "mapper_name":"ZPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"225",
-      "name":"kzpro_gull_pidr_reborn",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=642418824",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
-   },
-   {
-      "id":"737",
-      "name":"kzpro_justrun_sp",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1982407165",
-      "mapper_name":"Saicho",
-      "mapper_steamid64":"76561197995141366"
-   },
-   {
-      "id":"543",
-      "name":"kz_11342",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1155205561",
-      "mapper_name":"persona, geryuganshoop, GameChaos",
-      "mapper_steamid64":"76561198143205331, 76561198068278361, 76561198165203332"
-   },
-   {
-      "id":"566",
-      "name":"kz_11735",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1333248573",
-      "mapper_name":"persona, geryuganshoop",
-      "mapper_steamid64":"76561198143205331, 76561198068278361"
-   },
-   {
-      "id":"226",
-      "name":"kz_21loop_final_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=431789622",
-      "mapper_name":"Gemayue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"885",
-      "name":"kz_2fast",
-      "difficulty":"3",
-      "workshop_url":"http://steamcommunity.com/sharedfiles/filedetails/?id=636149777",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
-   },
-   {
-      "id":"227",
-      "name":"kz_2seasons_spring_final",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1242447001",
-      "mapper_name":"Gemayue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"581",
-      "name":"kz_2seasons_winter_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=793414645",
-      "mapper_name":"Gemayue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"870",
-      "name":"kz_420b",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=527350529",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
-   },
-   {
-      "id":"228",
-      "name":"kz_4u_nature",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1102436466",
-      "mapper_name":"Ivansky",
-      "mapper_steamid64":"76561198057742312"
-   },
-   {
-      "id":"229",
-      "name":"kz_7in1",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667950835",
-      "mapper_name":"Woozie"
-   },
-   {
-      "id":"862",
-      "name":"kz_8b1_brickngrass",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228982453",
-      "mapper_name":"8ball1, Fenikzz",
-      "mapper_steamid64":"76561198322296161, 76561198152002232"
-   },
-   {
-      "id":"738",
-      "name":"kz_aaaa",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1934946150",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"631",
-      "name":"kz_abandoned",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1581715482",
-      "mapper_name":"Lillen",
-      "mapper_steamid64":"76561198077858937"
-   },
-   {
-      "id":"230",
-      "name":"kz_abstruse_od2",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=841710228",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"231",
-      "name":"kz_adventure_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2233744660",
-      "mapper_name":"Ownkruid, GnargarN",
-      "mapper_steamid64":"76561197985107159, 76561198009902429"
-   },
-   {
-      "id":"232",
-      "name":"kz_adv_cursedjourney",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=248583000",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"752",
-      "name":"kz_aether_fix",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1901960163",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"642",
-      "name":"kz_afterlife",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1625094133",
-      "mapper_name":"Jony, Broiler",
-      "mapper_steamid64":"76561198000829729, 76561198136166348"
-   },
-   {
-      "id":"233",
-      "name":"kz_after_agitation_easy_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=793417352",
-      "mapper_name":"Gemayue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"234",
-      "name":"kz_agility_v2_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=392863247",
-      "mapper_name":"Aaron"
-   },
-   {
-      "id":"235",
-      "name":"kz_ahful",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580309446",
-      "mapper_name":"Ahful",
-      "mapper_steamid64":"76561198177735294"
-   },
-   {
-      "id":"236",
-      "name":"kz_akrh_warehouse_v2_gfix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939575987",
-      "mapper_name":"AssKicR"
-   },
-   {
-      "id":"929",
-      "name":"kz_alfama",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2327257272",
-      "mapper_name":"Rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"662",
-      "name":"kz_alfie",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1360984181",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"237",
-      "name":"kz_alice_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=478203041",
-      "mapper_name":"VVoodchip",
-      "mapper_steamid64":"76561198061948302"
-   },
-   {
-      "id":"759",
-      "name":"kz_alien_city",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2017349111",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"957",
-      "name":"kz_allure",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2423290876",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"922",
-      "name":"kz_alouette_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2347901033",
-      "mapper_name":"Alouette, nopey",
-      "mapper_steamid64":"76561198044981479, 76561198401447544"
-   },
-   {
-      "id":"881",
-      "name":"kz_alpha",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030049320",
-      "mapper_name":"Dima",
-      "mapper_steamid64":"76561198198062889"
-   },
-   {
-      "id":"882",
-      "name":"kz_altum_od",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2241212276",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"768",
-      "name":"kz_alt_aztec",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2069005326",
-      "mapper_name":"SinFuL, fucker",
-      "mapper_steamid64":"76561197970838363, 76561198243661942"
-   },
-   {
-      "id":"785",
-      "name":"kz_alt_cargo",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1947965934",
-      "mapper_name":"eiRa, GameChaos",
-      "mapper_steamid64":"76561197977069783, 76561198165203332"
-   },
-   {
-      "id":"646",
-      "name":"kz_amber_od",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1651410465",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"238",
-      "name":"kz_ancient_v3",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=576216273",
-      "mapper_name":"Verifyy",
-      "mapper_steamid64":"76561197995535364"
-   },
-   {
-      "id":"832",
-      "name":"kz_andromeda",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2193435024",
-      "mapper_name":"TheLlamaKing",
-      "mapper_steamid64":"76561197993284480"
-   },
-   {
-      "id":"830",
-      "name":"kz_angina_final",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2182136940",
-      "mapper_name":"daolang, temmie",
-      "mapper_steamid64":"76561198814294487,  76561198137502865"
-   },
-   {
-      "id":"923",
-      "name":"kz_anotherclimbmap",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2271036340",
-      "mapper_name":"therapysession, nopey",
-      "mapper_steamid64":"76561198012265008, 76561198401447544"
-   },
-   {
-      "id":"826",
-      "name":"kz_antharas",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2137813215",
-      "mapper_name":"Fksch",
-      "mapper_steamid64":"76561198142682783"
-   },
-   {
-      "id":"803",
-      "name":"kz_antigeneric",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2136461557",
-      "mapper_name":"rush2sk8, EchoFrost",
-      "mapper_steamid64":"76561198082904691, 76561198121144282"
-   },
-   {
-      "id":"805",
-      "name":"kz_antimony",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2027793498",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"914",
-      "name":"kz_antiquity",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2275579584",
-      "mapper_name":"JustErroR^, GameChaos",
-      "mapper_steamid64":"76561198150858529, 76561198165203332"
-   },
-   {
-      "id":"801",
-      "name":"kz_anus",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2134749919",
-      "mapper_name":"suna",
-      "mapper_steamid64":"76561198845462726"
-   },
-   {
-      "id":"647",
-      "name":"kz_arbitrary_words",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1658130511",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"239",
-      "name":"kz_arcadium",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1178668090",
-      "mapper_name":"ivansky",
-      "mapper_steamid64":"76561198057742312"
-   },
-   {
-      "id":"629",
-      "name":"kz_arcturus",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1587362542",
-      "mapper_name":"Espoon",
-      "mapper_steamid64":"76561198055373574"
-   },
-   {
-      "id":"939",
-      "name":"kz_armored_core",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381741747",
-      "mapper_name":"J3wDice",
-      "mapper_steamid64":"76561198208729343"
-   },
-   {
-      "id":"240",
-      "name":"kz_arrebol",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=846831175",
-      "mapper_name":"Nthng",
-      "mapper_steamid64":"76561198124649132"
-   },
-   {
-      "id":"241",
-      "name":"kz_ascend_hv",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357729700",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"921",
-      "name":"kz_ashen",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2308615315",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"242",
-      "name":"kz_asphyxiate",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1694955173",
-      "mapper_name":"sqrt, victoria248",
-      "mapper_steamid64":"null, 76561198026839022"
-   },
-   {
-      "id":"243",
-      "name":"kz_asteroid_field_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=333421749",
-      "mapper_name":"SoUlFaThEr",
-      "mapper_steamid64":"76561197965266419"
-   },
-   {
-      "id":"567",
-      "name":"kz_atelectasis_sct",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1887458950",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"684",
-      "name":"kz_athena",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753252198",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198044055747"
-   },
-   {
-      "id":"847",
-      "name":"kz_atlantis_od3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996497943",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"244",
-      "name":"kz_autobadges",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509624370",
-      "mapper_name":"Badges",
-      "mapper_steamid64":"76561197983438223"
-   },
-   {
-      "id":"663",
-      "name":"kz_autumn_valley_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1747171037",
-      "mapper_name":"iBUYFL0WER Birgit",
-      "mapper_steamid64":"76561198078014747"
-   },
-   {
-      "id":"815",
-      "name":"kz_avalon",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2191500128",
-      "mapper_name":"Michael",
-      "mapper_steamid64":"76561198004229810"
-   },
-   {
-      "id":"245",
-      "name":"kz_avoria",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1199062647",
-      "mapper_name":"Smex",
-      "mapper_steamid64":"76561197961558198"
-   },
-   {
-      "id":"246",
-      "name":"kz_aztec",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156057488",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"635",
-      "name":"kz_azure",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1563199395",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"664",
-      "name":"kz_babycat_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1708424560",
-      "mapper_name":"Schrødna ",
-      "mapper_steamid64":"76561198067192262"
-   },
-   {
-      "id":"598",
-      "name":"kz_bacho",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1481626092",
-      "mapper_name":"Sodawater",
-      "mapper_steamid64":"76561198180483758"
-   },
-   {
-      "id":"871",
-      "name":"kz_backwards",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2236890476",
-      "mapper_name":"Emzatin",
-      "mapper_steamid64":"76561198393292046"
-   },
-   {
-      "id":"247",
-      "name":"kz_bananaysoda_v2",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2156821612",
-      "mapper_name":"Jony, fucker",
-      "mapper_steamid64":"76561198000829729, 76561198243661942"
-   },
-   {
-      "id":"739",
-      "name":"kz_banjo",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753959953",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"248",
-      "name":"kz_basicnoon",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=379026993",
-      "mapper_name":"RVE",
-      "mapper_steamid64":"76561198014015385"
-   },
-   {
-      "id":"249",
-      "name":"kz_basics_b02",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519499813",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"599",
-      "name":"kz_baxter",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1366794864",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"834",
-      "name":"kz_beanguy_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2197490213",
-      "mapper_name":"shnart, Nopey",
-      "mapper_steamid64":"76561198045654331, 76561198401447544"
-   },
-   {
-      "id":"250",
-      "name":"kz_beginnerblock_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156057667",
-      "mapper_name":"Ovi"
-   },
-   {
-      "id":"916",
-      "name":"kz_betapmaps",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2325269071",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"251",
-      "name":"kz_betterdunjun",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=523852277",
-      "mapper_name":"DannyE",
-      "mapper_steamid64":"76561198178232629"
-   },
-   {
-      "id":"894",
-      "name":"kz_bhop_badges2",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1899371128",
-      "mapper_name":"badges, ρ",
-      "mapper_steamid64":"76561197983438223, 76561198002830622"
-   },
-   {
-      "id":"665",
-      "name":"kz_bhop_badges3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1726813996",
-      "mapper_name":"badges, ρ",
-      "mapper_steamid64":"76561197983438223, 76561198002830622"
-   },
-   {
-      "id":"691",
-      "name":"kz_bhop_benchmark",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1776449850",
-      "mapper_name":"badges, ρ",
-      "mapper_steamid64":"76561197983438223, 76561198002830622"
-   },
-   {
-      "id":"634",
-      "name":"kz_bhop_dusk_go",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1617628780",
-      "mapper_name":"CraizZ, ρ",
-      "mapper_steamid64":"76561197993271570, 76561198002830622"
-   },
-   {
-      "id":"252",
-      "name":"kz_bhop_essence",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
-      "mapper_name":"vay"
-      "mapper_steamid64":"76561198131632059"
-   },
-   {
-      "id":"898",
-      "name":"kz_bhop_koki_niwa",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2303161020",
-      "mapper_name":"noko",
-      "mapper_steamid64":"76561198013202660"
-   },
-   {
-      "id":"254",
-      "name":"kz_bhop_lj",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406077055",
-      "mapper_name":"badges",
-      "mapper_steamid64":"76561197983438223"
-   },
-   {
-      "id":"740",
-      "name":"kz_bhop_lucid",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1871085547",
-      "mapper_name":"keyuu, ρ",
-      "mapper_steamid64":"76561198003202977, 76561198002830622"
-   },
-   {
-      "id":"928",
-      "name":"kz_bhop_monsterjam",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2272849539",
-      "mapper_name":"Aoki, GameChaos",
-      "mapper_steamid64":"null, 76561198165203332"
-   },
-   {
-      "id":"582",
-      "name":"kz_bhop_mosaic_od2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=646510868",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"256",
-      "name":"kz_bhop_northface",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=642020842",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"544",
-      "name":"kz_bhop_nothing_go",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1204096299",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"794",
-      "name":"kz_bhop_sakura",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2124488428",
-      "mapper_name":".yuka, TheIceTiger, murray",
-      "mapper_steamid64":"null, 76561198022081031, 76561198019551123"
-   },
-   {
-      "id":"257",
-      "name":"kz_bhop_skyworld_go",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=678315907",
-      "mapper_name":"ρ, Orbit",
-      "mapper_steamid64":"76561198002830622, 76561198057269402"
-   },
-   {
-      "id":"258",
-      "name":"kz_bhop_watertemple",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519457034",
-      "mapper_name":"Daza, SoUlFaThEr, zPrince",
-      "mapper_steamid64":"76561198007996091, 76561197965266419, 76561198047032125"
-   },
-   {
-      "id":"600",
-      "name":"kz_bhop_zenith",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=715243400",
-      "mapper_name":"Zorb, Cyclo",
-      "mapper_steamid64":"76561198144259350, 76561198024466262"
-   },
-   {
-      "id":"624",
-      "name":"kz_bible_black",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1617624549",
-      "mapper_name":"victoria248",
-      "mapper_steamid64":"76561198026839022"
-   },
-   {
-      "id":"920",
-      "name":"kz_bigcastle",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2303795750",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"769",
-      "name":"kz_binseebak",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2096008736",
-      "mapper_name":"L1nus",
-      "mapper_steamid64":"76561198835361052"
-   },
-   {
-      "id":"259",
-      "name":"kz_bionic",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=598309769",
-      "mapper_name":"Zorb",
-      "mapper_steamid64":"76561198144259350"
-   },
-   {
-      "id":"879",
-      "name":"kz_birrita_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240515420",
-      "mapper_name":"HermeticA",
-      "mapper_steamid64":"76561198082476569"
-   },
-   {
-      "id":"741",
-      "name":"kz_bir_dont_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2002208768",
-      "mapper_name":"Bird",
-      "mapper_steamid64":"76561198061987188"
-   },
-   {
-      "id":"641",
-      "name":"kz_blackness",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1582682050",
-      "mapper_name":"Jony",
-      "mapper_steamid64":"76561198000829729"
-   },
-   {
-      "id":"260",
-      "name":"kz_blatherskite_v1",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1201400569",
-      "mapper_name":"DannyE",
-      "mapper_steamid64":"76561198178232629"
-   },
-   {
-      "id":"261",
-      "name":"kz_blindcity_easy_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=673671001",
-      "mapper_name":"GemaYue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"262",
-      "name":"kz_blindcity_hard_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=450945426",
-      "mapper_name":"GemaYue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"618",
-      "name":"kz_blocks2006",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627115733",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"823",
-      "name":"kz_bloodline",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2169096895",
-      "mapper_name":"Makis",
-      "mapper_steamid64":"76561198201492663"
-   },
-   {
-      "id":"263",
-      "name":"kz_bluehop_mq",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1241443665",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"264",
-      "name":"kz_bluerace_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667952586",
-      "mapper_name":"tr4mp"
-   },
-   {
-      "id":"941",
-      "name":"kz_bluuu",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2416991755",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"601",
-      "name":"kz_bombu",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=742494584",
-      "mapper_name":"Bombu",
-      "mapper_steamid64":"76561198217095940"
-   },
-   {
-      "id":"849",
-      "name":"kz_boomblock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2206472013",
-      "mapper_name":"Szwagi",
-      "mapper_steamid64":"76561198857828380"
-   },
-   {
-      "id":"796",
-      "name":"kz_bounce",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2118830049",
-      "mapper_name":"Makis",
-      "mapper_steamid64":"76561198201492663"
-   },
-   {
-      "id":"265",
-      "name":"kz_breezeblocks",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=898027127",
-      "mapper_name":"BreeZ",
-      "mapper_steamid64":"76561198339346625"
-   },
-   {
-      "id":"266",
-      "name":"kz_brickblock_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=621434939",
-      "mapper_name":"masque, DanZay",
-      "mapper_steamid64":"76561197979436335, 76561197989817982"
-   },
-   {
-      "id":"926",
-      "name":"kz_bridge17_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2309106000",
-      "mapper_name":"pr3da, _max",
-      "mapper_steamid64":"76561198021246024, 76561198083065598"
-   },
-   {
-      "id":"267",
-      "name":"kz_brightblock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=653272914",
-      "mapper_name":"bboc",
-      "mapper_steamid64":"76561198000159327"
-   },
-   {
-      "id":"268",
-      "name":"kz_buildings_final",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406077441",
-      "mapper_name":"Vypur",
-      "mapper_steamid64":"76561198027553039"
-   },
-   {
-      "id":"895",
-      "name":"kz_burnished",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2120360302",
-      "mapper_name":"L1nus",
-      "mapper_steamid64":"76561198835361052"
-   },
-   {
-      "id":"911",
-      "name":"kz_byrem",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2327576026",
-      "mapper_name":"Rem, Antosha*",
-      "mapper_steamid64":"76561198072336874, 76561197974898839"
-   },
-   {
-      "id":"686",
-      "name":"kz_cabin_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240379784",
-      "mapper_name":"mjb",
-      "mapper_steamid64":"76561198093921774"
-   },
-   {
-      "id":"270",
-      "name":"kz_camembert",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=808050906",
-      "mapper_name":"BOWql",
-      "mapper_steamid64":"76561198190304705"
-   },
-   {
-      "id":"271",
-      "name":"kz_canyon",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=621630951",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"583",
-      "name":"kz_carbon",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1398723898",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"798",
-      "name":"kz_cargo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279210694",
-      "mapper_name":"eiRa, Alouette",
-      "mapper_steamid64":"null, 76561198044981479"
-   },
-   {
-      "id":"864",
-      "name":"kz_carp_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2241460284",
-      "mapper_name":"Andi, Nopey",
-      "mapper_steamid64":"76561198156668976, 76561198401447544"
-   },
-   {
-      "id":"272",
-      "name":"kz_cartooncastle_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
-      "mapper_name":"s0liD, karatekafer"
-      "mapper_steamid64":"76561197980460370, null"
-   },
-   {
-      "id":"918",
-      "name":"kz_cascade_v4",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2356578123",
-      "mapper_name":"KingGambit",
-      "mapper_steamid64":"76561198023829871"
-   },
-   {
-      "id":"621",
-      "name":"kz_castlehops_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116280",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"274",
-      "name":"kz_cataclysm",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370545981",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"275",
-      "name":"kz_catalyst_gfix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939576543",
-      "mapper_name":"umbrella"
-   },
-   {
-      "id":"276",
-      "name":"kz_catharsis_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=615332047",
-      "mapper_name":"kaldren.",
-      "mapper_steamid64":"76561197972347749"
-   },
-   {
-      "id":"277",
-      "name":"kz_caulis_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058093",
-      "mapper_name":"Millet"
-   },
-   {
-      "id":"568",
-      "name":"kz_cdr_myst",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1391753126",
-      "mapper_name":"Dunk",
-      "mapper_steamid64":"76561197987174004"
-   },
-   {
-      "id":"627",
-      "name":"kz_cdr_rustenborg",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1401830672",
-      "mapper_name":"Dunk",
-      "mapper_steamid64":"76561197987174004"
-   },
-   {
-      "id":"569",
-      "name":"kz_cdr_slash_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1391789057",
-      "mapper_name":"Dunk",
-      "mapper_steamid64":"76561197987174004"
-   },
-   {
-      "id":"760",
-      "name":"kz_celestial",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2059174492",
-      "mapper_name":"mjb",
-      "mapper_steamid64":"76561198093921774"
-   },
-   {
-      "id":"278",
-      "name":"kz_cellblock_go2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156058850",
-      "mapper_name":"Millet"
-   },
-   {
-      "id":"814",
-      "name":"kz_cereal",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2176136694",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"279",
-      "name":"kz_cg_brick_rmk",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688171253",
-      "mapper_name":"InseN"
-   },
-   {
-      "id":"280",
-      "name":"kz_cg_lighthops_go",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352286796",
-      "mapper_name":"Mentalo, OldHead",
-      "mapper_steamid64":"null, 76561198009989298"
-   },
-   {
-      "id":"619",
-      "name":"kz_checkmate",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1535993215",
-      "mapper_name":"GameChaos",
-      "mapper_steamid64":"76561198165203332"
-   },
-   {
-      "id":"848",
-      "name":"kz_cheese",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2204525929",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"281",
-      "name":"kz_cheetos_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2234432420",
-      "mapper_name":"pe, Nopey",
-      "mapper_steamid64":"76561198212205417, 76561198401447544"
-   },
-   {
-      "id":"282",
-      "name":"kz_chessblock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=576215645",
-      "mapper_name":"AFlyingGuru"
-   },
-   {
-      "id":"283",
-      "name":"kz_chinablock",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279166189",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"840",
-      "name":"kz_chloroplast",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2194393186",
-      "mapper_name":"Plastyc",
-      "mapper_steamid64":"76561199024218227"
-   },
-   {
-      "id":"742",
-      "name":"kz_choka_fix",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1933623975",
-      "mapper_name":"JJ",
-      "mapper_steamid64":"76561198167125526"
-   },
-   {
-      "id":"897",
-      "name":"kz_chopchop",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187656713",
-      "mapper_name":"Sehk",
-      "mapper_steamid64":"76561198037724970"
-   },
-   {
-      "id":"284",
-      "name":"kz_christmas_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=669198796",
-      "mapper_name":"geryuganshoop",
-      "mapper_steamid64":"76561198068278361"
-   },
-   {
-      "id":"892",
-      "name":"kz_chrysoprase",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2237697111",
-      "mapper_name":"Michael",
-      "mapper_steamid64":"76561198004229810"
-   },
-   {
-      "id":"902",
-      "name":"kz_chunky_peanut_butter",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259665094",
-      "mapper_name":"rov",
-      "mapper_steamid64":"76561198132236283"
-   },
-   {
-      "id":"636",
-      "name":"kz_citadel",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1546644939",
-      "mapper_name":"aleiux",
-      "mapper_steamid64":"76561198090798444"
-   },
-   {
-      "id":"753",
-      "name":"kz_civilizations",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2034478444",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"285",
-      "name":"kz_cliffhanger_go_global",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=504851319",
-      "mapper_name":"Blind",
-      "mapper_steamid64":"76561198152317855"
-   },
-   {
-      "id":"825",
-      "name":"kz_coastline_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2171603497",
-      "mapper_name":"Steelo, Nopey",
-      "mapper_steamid64":"76561198279205361, 76561198401447544"
-   },
-   {
-      "id":"286",
-      "name":"kz_colorcode",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=528597060",
-      "mapper_name":"schm0ftie",
-      "mapper_steamid64":"76561197983561860"
-   },
-   {
-      "id":"287",
-      "name":"kz_colors_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=325027910",
-      "mapper_name":"Wally",
-      "mapper_steamid64":"76561197967777192"
-   },
-   {
-      "id":"288",
-      "name":"kz_combobreaker",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=908525075",
-      "mapper_name":"GameChaos",
-      "mapper_steamid64":"76561198165203332"
-   },
-   {
-      "id":"289",
-      "name":"kz_combohop_c02",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519498732",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"570",
-      "name":"kz_comboya",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1256315105",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"290",
-      "name":"kz_communityjump3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=659804813",
-      "mapper_name":"KZ Community"
-   },
-   {
-      "id":"291",
-      "name":"kz_complex",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=386875795",
-      "mapper_name":"teh_grave, DropInMilk",
-      "mapper_steamid64":"null, 76561198033385282"
-   },
-   {
-      "id":"292",
-      "name":"kz_comp_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053614",
-      "mapper_name":"ella",
-      "mapper_steamid64":"76561198069465729"
-   },
-   {
-      "id":"293",
-      "name":"kz_concept",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=903732207",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"294",
-      "name":"kz_concretejungle",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=506427184",
-      "mapper_name":"rev",
-      "mapper_steamid64":"76561197981308142"
-   },
-   {
-      "id":"650",
-      "name":"kz_conifer",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1699121278",
-      "mapper_name":"victoria248, GameChaos",
-      "mapper_steamid64":"76561198026839022, 76561198165203332"
-   },
-   {
-      "id":"295",
-      "name":"kz_conrun_mq",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=381648804",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"296",
-      "name":"kz_conrun_scrub",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=382262763",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"297",
-      "name":"kz_conspiracy",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=896555313",
-      "mapper_name":"Jakobe",
-      "mapper_steamid64":"76561198072850237"
-   },
-   {
-      "id":"298",
-      "name":"kz_construction",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=499184114",
-      "mapper_name":"finckelton",
-      "mapper_steamid64":"76561198039388458"
-   },
-   {
-      "id":"683",
-      "name":"kz_continuum",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1464119184",
-      "mapper_name":"Crash",
-      "mapper_steamid64":"76561197981212562"
-   },
-   {
-      "id":"552",
-      "name":"kz_coronado_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1381132298",
-      "mapper_name":"Cyclo",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"602",
-      "name":"kz_correguachin_reisido",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187796868",
-      "mapper_name":"Shendal",
-      "mapper_steamid64":"76561198225775664"
-   },
-   {
-      "id":"545",
-      "name":"kz_cousucks",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1241648205",
-      "mapper_name":"Krushed",
-      "mapper_steamid64":"76561197966948458"
-   },
-   {
-      "id":"943",
-      "name":"kz_cranking_the_hog",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381788599",
-      "mapper_name":"rov",
-      "mapper_steamid64":"76561198132236283"
-   },
-   {
-      "id":"828",
-      "name":"kz_crash_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2163399474",
-      "mapper_name":"Alouette, nopey",
-      "mapper_steamid64":"76561198044981479, 76561198401447544"
-   },
-   {
-      "id":"299",
-      "name":"kz_cratespeed",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=689965741",
-      "mapper_name":"ruben",
-      "mapper_steamid64":"76561198100183392"
-   },
-   {
-      "id":"300",
-      "name":"kz_crate_delight_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491405849",
-      "mapper_name":"SoUlFaThEr, zPrince",
-      "mapper_steamid64":"76561197965266419, 76561198047032125"
-   },
-   {
-      "id":"301",
-      "name":"kz_crypt_final",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=528128872",
-      "mapper_name":"Ryborg",
-      "mapper_steamid64":"76561198101913104"
-   },
-   {
-      "id":"302",
-      "name":"kz_crysis",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387238555",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"953",
-      "name":"kz_cuberunfast",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2420438992",
-      "mapper_name":"DannyE",
-      "mapper_steamid64":"76561198178232629"
-   },
-   {
-      "id":"303",
-      "name":"kz_custos",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1135144334",
-      "mapper_name":"xq, GameChaos",
-      "mapper_steamid64":"76561198094382485, 76561198165203332"
-   },
-   {
-      "id":"712",
-      "name":"kz_cyberspace_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996119569",
-      "mapper_name":"Charon",
-      "mapper_steamid64":"76561197979938663"
-   },
-   {
-      "id":"304",
-      "name":"kz_cyb_adrenaline_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1780391218",
-      "mapper_name":"cybur, masque",
-      "mapper_steamid64":"76561198062384407, 76561197979436335"
-   },
-   {
-      "id":"553",
-      "name":"kz_dakow",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1278987653",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"613",
-      "name":"kz_dale",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627116834",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"305",
-      "name":"kz_dam",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=647694230",
-      "mapper_name":"pr3da",
-      "mapper_steamid64":"76561198021246024"
-   },
-   {
-      "id":"306",
-      "name":"kz_daniel",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=416827844",
-      "mapper_name":"Khaleese",
-      "mapper_steamid64":"76561198123676539"
-   },
-   {
-      "id":"770",
-      "name":"kz_dank_stacks",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2075152351",
-      "mapper_name":"DankD",
-      "mapper_steamid64":"76561198039728576"
-   },
-   {
-      "id":"924",
-      "name":"kz_dark_fury",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2380315439",
-      "mapper_name":"sn00p, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
-   },
-   {
-      "id":"307",
-      "name":"kz_date2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406439108",
-      "mapper_name":"s0liD, DropInMilk",
-      "mapper_steamid64":"76561197980460370, 76561198033385282"
-   },
-   {
-      "id":"308",
-      "name":"kz_default",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=382377001",
-      "mapper_name":"DropinMilk",
-      "mapper_steamid64":"76561198033385282"
-   },
-   {
-      "id":"622",
-      "name":"kz_dejavu",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1539800895",
-      "mapper_name":"Fnugz",
-      "mapper_steamid64":"76561198012891563"
-   },
-   {
-      "id":"811",
-      "name":"kz_delphinium",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2145751608",
-      "mapper_name":"Michael",
-      "mapper_steamid64":"76561198004229810"
-   },
-   {
-      "id":"309",
-      "name":"kz_depot",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=738046973",
-      "mapper_name":"f3vo",
-      "mapper_steamid64":"76561198040677227"
-   },
-   {
-      "id":"554",
-      "name":"kz_dethroned",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1295359223",
-      "mapper_name":"Cyclo",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"310",
-      "name":"kz_de_bhop",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509624659"
-   },
-   {
-      "id":"651",
-      "name":"kz_diajonal",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1626046474",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"311",
-      "name":"kz_dimensions_v1",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491411804",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"312",
-      "name":"kz_district_d01",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=421427380",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"908",
-      "name":"kz_divided",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2330433609",
-      "mapper_name":"J3wDice",
-      "mapper_steamid64":"76561198208729343"
-   },
-   {
-      "id":"925",
-      "name":"kz_dontjump",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2276652300",
-      "mapper_name":"Emzatin",
-      "mapper_steamid64":"76561198393292046"
-   },
-   {
-      "id":"313",
-      "name":"kz_doubletake",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491377297",
-      "mapper_name":"BeastF",
-      "mapper_steamid64":"76561197992587981"
-   },
-   {
-      "id":"314",
-      "name":"kz_doveen",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=391996291",
-      "mapper_name":"DoveeN",
-      "mapper_steamid64":"76561198033299991"
-   },
-   {
-      "id":"315",
-      "name":"kz_drops_od",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=631559848",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"937",
-      "name":"kz_drunkards",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2422272884",
-      "mapper_name":"Plastyc",
-      "mapper_steamid64":"76561199024218227"
-   },
-   {
-      "id":"316",
-      "name":"kz_dryness",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=611091154",
-      "mapper_name":"pr3da",
-      "mapper_steamid64":"76561198021246024"
-   },
-   {
-      "id":"317",
-      "name":"kz_duality_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1851066208",
-      "mapper_name":"VVoodchip, Zach47",
-      "mapper_steamid64":"76561198061948302, 76561197983014207"
-   },
-   {
-      "id":"318",
-      "name":"kz_dungeon",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515635506",
-      "mapper_name":"RyBorg",
-      "mapper_steamid64":"76561198101913104"
-   },
-   {
-      "id":"850",
-      "name":"kz_dust",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2187288428",
-      "mapper_name":"L1nus",
-      "mapper_steamid64":"76561198835361052"
-   },
-   {
-      "id":"319",
-      "name":"kz_dvn_cube_fixed",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498765580",
-      "mapper_name":"DoveeN",
-      "mapper_steamid64":"76561198033299991"
-   },
-   {
-      "id":"320",
-      "name":"kz_dvn_dull",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=483073135",
-      "mapper_name":"DoveeN",
-      "mapper_steamid64":"76561198033299991"
-   },
-   {
-      "id":"321",
-      "name":"kz_dvn_redcarpet",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=605822998",
-      "mapper_name":"DoveeN",
-      "mapper_steamid64":"76561198033299991"
-   },
-   {
-      "id":"713",
-      "name":"kz_dyd_ladderjumps",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1653452291",
-      "mapper_name":"dydka, GameChaos",
-      "mapper_steamid64":"76561198010747369, 76561198165203332"
-   },
-   {
-      "id":"322",
-      "name":"kz_dzy_beyond_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=454227310",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"323",
-      "name":"kz_dzy_reach_v2",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=673887976",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"324",
-      "name":"kz_ea_beneath_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=338561631",
-      "mapper_name":"rad0n, old head",
-      "mapper_steamid64":"null, 76561198009989298"
-   },
-   {
-      "id":"873",
-      "name":"kz_echo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259659098",
-      "mapper_name":"mjb",
-      "mapper_steamid64":"76561198093921774"
-   },
-   {
-      "id":"325",
-      "name":"kz_edifice",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=930321498",
-      "mapper_name":"Crixzzi",
-      "mapper_steamid64":"76561198046307458"
-   },
-   {
-      "id":"667",
-      "name":"kz_edp445",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1755737510",
-      "mapper_name":"victoria248",
-      "mapper_steamid64":"76561198026839022"
-   },
-   {
-      "id":"623",
-      "name":"kz_egyptianbox",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1576706552",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"326",
-      "name":"kz_emblem",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=489591399",
-      "mapper_name":"SinFul, Timmycakes",
-      "mapper_steamid64":"76561197970838363, 0"
-   },
-   {
-      "id":"327",
-      "name":"kz_emblem_bonus",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491412109",
-      "mapper_name":"SinFul, Timmycakes",
-      "mapper_steamid64":"76561197970838363, 0"
-   },
-   {
-      "id":"838",
-      "name":"kz_emptiness",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2203626680",
-      "mapper_name":"SneakY",
-      "mapper_steamid64":"76561198251129150"
-   },
-   {
-      "id":"328",
-      "name":"kz_ephemeral",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=692077375",
-      "mapper_name":"Tapzie",
-      "mapper_steamid64":"76561198122678894"
-   },
-   {
-      "id":"584",
-      "name":"kz_epiphany_v2",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1386147078",
-      "mapper_name":"Cyclo",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"329",
-      "name":"kz_epusbridge",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=303863578",
-      "mapper_name":"Deepus",
-      "mapper_steamid64":"76561197976153012"
-   },
-   {
-      "id":"930",
-      "name":"kz_erbajerb",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2304761102",
-      "mapper_name":"Birgit",
-      "mapper_steamid64":"76561198078014747"
-   },
-   {
-      "id":"330",
-      "name":"kz_erinome",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=568096729",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"331",
-      "name":"kz_eros_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=791910412",
-      "mapper_name":"finckelton, Kiwi",
-      "mapper_steamid64":"76561198039388458, 76561198077353609"
-   },
-   {
-      "id":"546",
-      "name":"kz_erratum_v2",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1170612689",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"936",
-      "name":"kz_eudora",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2312833379",
-      "mapper_name":"nowimime",
-      "mapper_steamid64":"76561198077383803"
-   },
-   {
-      "id":"585",
-      "name":"kz_eventide",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1382667484",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"799",
-      "name":"kz_everything",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2069925634",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"714",
-      "name":"kz_evilcorp",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1904796339",
-      "mapper_name":"Magier",
-      "mapper_steamid64":"76561198103471850"
-   },
-   {
-      "id":"332",
-      "name":"kz_excape",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406079956",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64": "76561198040798967"
-   },
-   {
-      "id":"333",
-      "name":"kz_excavate_b",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1440554662",
-      "mapper_name":"Badges",
-      "mapper_steamid64":"76561197983438223"
-   },
-   {
-      "id":"831",
-      "name":"kz_exemplum_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228224629",
-      "mapper_name":"Makis",
-      "mapper_steamid64":"76561198201492663"
-   },
-   {
-      "id":"334",
-      "name":"kz_exoteric",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=380505617",
-      "mapper_name":"Energy",
-      "mapper_steamid64":"76561198084022373"
-   },
-   {
-      "id":"335",
-      "name":"kz_experiment",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=398489890",
-      "mapper_name":"TheWhaleMan",
-      "mapper_steamid64":"76561198064508818"
-   },
-   {
-      "id":"336",
-      "name":"kz_exps_cursedjourney",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=525288912",
-      "mapper_name":"SinFul",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"337",
-      "name":"kz_ext_bblocks",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352448183",
-      "mapper_name":"Extermerz"
-   },
-   {
-      "id":"338",
-      "name":"kz_fabrik",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=221328962",
-      "mapper_name":"Snorres",
-      "mapper_steamid64":"76561197986556153"
-   },
-   {
-      "id":"339",
-      "name":"kz_failed_fastrun_rt",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688361058",
-      "mapper_name":"0n1yF4r7"
-   },
-   {
-      "id":"692",
-      "name":"kz_farm_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1750701302",
-      "mapper_name":"Chris, GameChaos",
-      "mapper_steamid64":"76561198044472964, 76561198165203332"
-   },
-   {
-      "id":"693",
-      "name":"kz_fas2map",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1699101066",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"340",
-      "name":"kz_fastcombomap",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=760052560",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"603",
-      "name":"kz_fastmap",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1448528308",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"341",
-      "name":"kz_fatigue_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=375133191",
-      "mapper_name":"Energy",
-      "mapper_steamid64":"76561198084022373"
-   },
-   {
-      "id":"342",
-      "name":"kz_fikablock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=674086581",
-      "mapper_name":"Jmonsted",
-      "mapper_steamid64":"76561198071182150"
-   },
-   {
-      "id":"343",
-      "name":"kz_final_ascension",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=551807622",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"694",
-      "name":"kz_flabbergast",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1770987028",
-      "mapper_name":"CyclO",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"344",
-      "name":"kz_floatingislands",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=738956347",
-      "mapper_name":"lillen",
-      "mapper_steamid64":"76561198077858937"
-   },
-   {
-      "id":"614",
-      "name":"kz_flying_rabbits",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627117444",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"888",
-      "name":"kz_fly_lovers",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2012561467",
-      "mapper_name":"Deppy, persona",
-      "mapper_steamid64":"null, 76561198143205331"
-   },
-   {
-      "id":"345",
-      "name":"kz_foggywarehouse_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387995227",
-      "mapper_name":"pb",
-      "mapper_steamid64":"76561197971221508"
-   },
-   {
-      "id":"253",
-      "name":"kz_forchi",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1860299808",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"346",
-      "name":"kz_forestrace_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=337879628",
-      "mapper_name":"h1m1, old head",
-      "mapper_steamid64":"null, 76561198009989298"
-   },
-   {
-      "id":"695",
-      "name":"kz_forgettable",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1399481815",
-      "mapper_name":"River",
-      "mapper_steamid64":"76561198054436805"
-   },
-   {
-      "id":"547",
-      "name":"kz_forgotten_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1213870327",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"347",
-      "name":"kz_free_ahful",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1167761258",
-      "mapper_name":"Persona",
-      "mapper_steamid64":"76561198143205331"
-   },
-   {
-      "id":"348",
-      "name":"kz_frozen_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066122",
-      "mapper_name":"SoUlFaThEr, SinFuL",
-      "mapper_steamid64":"76561197965266419, 76561197970838363"
-   },
-   {
-      "id":"884",
-      "name":"kz_fury",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224298709",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"652",
-      "name":"kz_fused",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1715598348",
-      "mapper_name":"mjb",
-      "mapper_steamid64":"76561198093921774"
-   },
-   {
-      "id":"349",
-      "name":"kz_futureblock",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320897168",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"350",
-      "name":"kz_galaxy_go2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066234",
-      "mapper_name":"Woozie"
-   },
-   {
-      "id":"548",
-      "name":"kz_gallus",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=890259285",
-      "mapper_name":"Karo, Diesel",
-      "mapper_steamid64":"76561198059165508, 76561198099241969"
-   },
-   {
-      "id":"913",
-      "name":"kz_gary",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2280509631",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"474",
-      "name":"kz_gc_shark",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2080951339",
-      "mapper_name":"nykaN, GameChaos",
-      "mapper_steamid64":"76561198014491259, 76561198165203332"
-   },
-   {
-      "id":"643",
-      "name":"kz_gemischte_gefuehlslagen",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1280314788",
-      "mapper_name":"Heinzelboss",
-      "mapper_steamid64":"76561198155043164"
-   },
-   {
-      "id":"761",
-      "name":"kz_generic",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2047349909",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"351",
-      "name":"kz_genesis_go2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
-      "mapper_name":"FoF"
-      "mapper_steamid64":"76561197991832101"
-   },
-   {
-      "id":"352",
-      "name":"kz_gfy_blueberry",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=336069751",
-      "mapper_name":"Wally",
-      "mapper_steamid64":"76561197967777192"
-   },
-   {
-      "id":"353",
-      "name":"kz_gfy_c0mb0king",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352458126",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"354",
-      "name":"kz_gfy_devcastle",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399926903",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"355",
-      "name":"kz_gfy_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=438483912",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"356",
-      "name":"kz_gfy_fortroca_finallll",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352459359",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"357",
-      "name":"kz_gfy_limit",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=441312733",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"358",
-      "name":"kz_gfy_strawberry_",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352456857",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"359",
-      "name":"kz_gfy_tech",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409983599",
-      "mapper_name":"winterNebs",
-      "mapper_steamid64":"76561198040798967"
-   },
-   {
-      "id":"360",
-      "name":"kz_ggurk",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1139544827",
-      "mapper_name":"AFlyingGuru, Flow",
-      "mapper_steamid64":"null, 76561197991750093"
-   },
-   {
-      "id":"617",
-      "name":"kz_ghat",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118013",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"361",
-      "name":"kz_giantbean",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066438",
-      "mapper_name":"KreedZ, SinFuL",
-      "mapper_steamid64":"76561197997103423, 76561197970838363"
-   },
-   {
-      "id":"362",
-      "name":"kz_gigablock_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
-      "mapper_name":"KreedZ, Spherix",
-      "mapper_steamid64":"76561198016516359, null"
-   },
-   {
-      "id":"363",
-      "name":"kz_gitgud_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370366679",
-      "mapper_name":"VypuR",
-      "mapper_steamid64":"76561198027553039"
-   },
-   {
-      "id":"863",
-      "name":"kz_gkd_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2240110192",
-      "mapper_name":"Ap",
-      "mapper_steamid64":"76561198331631430"
-   },
-   {
-      "id":"364",
-      "name":"kz_glassesospa_v1",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=212501969",
-      "mapper_name":"Ospa",
-      "mapper_steamid64":"76561197992548863"
-   },
-   {
-      "id":"804",
-      "name":"kz_glide",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1816942862",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"668",
-      "name":"kz_gloom",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1747028736",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"653",
-      "name":"kz_gobbledygook",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1458270387",
-      "mapper_name":"J4BEE, Persona",
-      "mapper_steamid64":"76561198168982111, 76561198143205331"
-   },
-   {
-      "id":"365",
-      "name":"kz_goldenroad",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=227198727",
-      "mapper_name":"Ospa, Al2x",
-      "mapper_steamid64":"76561197992548863, 76561198037766292"
-   },
-   {
-      "id":"696",
-      "name":"kz_goldentabby",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1742520143",
-      "mapper_name":"ShadowBladeXtrm",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"366",
-      "name":"kz_gonbe",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=388981512",
-      "mapper_name":"skitty",
-      "mapper_steamid64":"76561198031452487"
-   },
-   {
-      "id":"367",
-      "name":"kz_goodluck_p",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=315108801",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"638",
-      "name":"kz_goquicklol_v2",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1674495693",
-      "mapper_name":"Mark",
-      "mapper_steamid64":"76561198045869085"
-   },
-   {
-      "id":"368",
-      "name":"kz_grass_hard",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491359087",
-      "mapper_name":"Extremerz",
-      "mapper_steamid64":"76561197965479288"
-   },
-   {
-      "id":"369",
-      "name":"kz_green",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=425209295",
-      "mapper_name":"Piu",
-      "mapper_steamid64":"76561198014009703"
-   },
-   {
-      "id":"370",
-      "name":"kz_gy_agitation",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=444123619",
-      "mapper_name":"Gemayue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"371",
-      "name":"kz_haki_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156066638",
-      "mapper_name":"a$ce"
-   },
-   {
-      "id":"499",
-      "name":"kz_halicarnassus_fs",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2080802644",
-      "mapper_name":"Zengal, SinFuL",
-      "mapper_steamid64":"null, 76561197970838363"
-   },
-   {
-      "id":"792",
-      "name":"kz_hammer",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2133476426",
-      "mapper_name":"Makis",
-      "mapper_steamid64":"76561198201492663"
-   },
-   {
-      "id":"717",
-      "name":"kz_haste",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1877331884",
-      "mapper_name":"Dillon",
-      "mapper_steamid64":"76561198120868833"
-   },
-   {
-      "id":"372",
-      "name":"kz_hate",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=875611390",
-      "mapper_name":"Yams",
-      "mapper_steamid64":"76561198348576275"
-   },
-   {
-      "id":"373",
-      "name":"kz_heatvents_mq",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=459351652",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"697",
-      "name":"kz_heaven_od",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1705891534",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"843",
-      "name":"kz_hek",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2175513019",
-      "mapper_name":"Pigeon",
-      "mapper_steamid64":"76561198164405482"
-   },
-   {
-      "id":"374",
-      "name":"kz_hellinashop",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515649978",
-      "mapper_name":"8Ball1, SinFuL",
-      "mapper_steamid64":"null, 76561197970838363"
-   },
-   {
-      "id":"839",
-      "name":"kz_hemochromatosis",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2044616297",
-      "mapper_name":"rov",
-      "mapper_steamid64":"76561198132236283"
-   },
-   {
-      "id":"375",
-      "name":"kz_highland",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=656212893",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"719",
-      "name":"kz_high_socks",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1984921434",
-      "mapper_name":"GameChaos, Samuel",
-      "mapper_steamid64":"76561198165203332, 76561198191875674"
-   },
-   {
-      "id":"586",
-      "name":"kz_hikari_od",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=884785011",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"377",
-      "name":"kz_hillside",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
-      "mapper_name":"s0liD"
-      "mapper_steamid64":"76561197980460370"
-   },
-   {
-      "id":"376",
-      "name":"kz_hitech",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2002217295",
-      "mapper_name":"nykaN",
-      "mapper_steamid64":"76561198014491259"
-   },
-   {
-      "id":"681",
-      "name":"kz_holyspace",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1771753813",
-      "mapper_name":"SodaWater",
-      "mapper_steamid64":"76561198180483758"
-   },
-   {
-      "id":"817",
-      "name":"kz_how2slide_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2166904834",
-      "mapper_name":"Dima",
-      "mapper_steamid64":"76561198198062889"
-   },
-   {
-      "id":"720",
-      "name":"kz_huber",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1702853550",
-      "mapper_name":"Durox",
-      "mapper_steamid64":"76561198072521803"
-   },
-   {
-      "id":"378",
-      "name":"kz_ickkck",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=822776276",
-      "mapper_name":"Rosquilla Guy",
-      "mapper_steamid64":"76561198102575797"
-   },
-   {
-      "id":"379",
-      "name":"kz_illusion_gfix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939577141",
-      "mapper_name":"schm0ftie",
-      "mapper_steamid64":"76561197983561860"
-   },
-   {
-      "id":"380",
-      "name":"kz_iluvprok_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406053852",
-      "mapper_name":"Nitekillr",
-      "mapper_steamid64":"76561197987002717"
-   },
-   {
-      "id":"381",
-      "name":"kz_imaginary_final",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=843659203",
-      "mapper_name":"JONY",
-      "mapper_steamid64":"76561198000829729"
-   },
-   {
-      "id":"382",
-      "name":"kz_innit",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1209786787",
-      "mapper_name":"bainz, GameChaos, Danvari",
-      "mapper_steamid64":"76561198183817078, 76561198165203332, 76561198038388449"
-   },
-   {
-      "id":"383",
-      "name":"kz_insomnia_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=594168198",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"384",
-      "name":"kz_inspired",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=370117755",
-      "mapper_name":"Kaldren",
-      "mapper_steamid64":"76561197972347749"
-   },
-   {
-      "id":"860",
-      "name":"kz_intercourse!",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207574101",
-      "mapper_name":"stz",
-      "mapper_steamid64":"76561198261992780"
-   },
-   {
-      "id":"385",
-      "name":"kz_internatus",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=551443219",
-      "mapper_name":"Deepus",
-      "mapper_steamid64":"76561197976153012"
-   },
-   {
-      "id":"386",
-      "name":"kz_island",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357579568",
-      "mapper_name":"JumBoO",
-      "mapper_steamid64":"7656119813262611"
-   },
-   {
-      "id":"950",
-      "name":"kz_itz_transcendent",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2373968399",
-      "mapper_name":"iTz",
-      "mapper_steamid64":"76561198104765796"
-   },
-   {
-      "id":"387",
-      "name":"kz_j2s_cupblock_go_fix2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
-      "mapper_name":"s0lid, Spherix"
-      "mapper_steamid64":"76561197980460370, null"
-   },
-   {
-      "id":"388",
-      "name":"kz_j2s_tetris_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
-      "mapper_name":"s0lid, fl0w",
-      "mapper_steamid64":"76561197980460370, 76561197991750093"
-   },
-   {
-      "id":"389",
-      "name":"kz_j2s_westbl0ck",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
-      "mapper_name":"s0lid, fl0w, DanZay",
-      "mapper_steamid64":"76561197980460370, 76561197991750093, 76561197989817982"
-   },
-   {
-      "id":"390",
-      "name":"kz_janpu_final_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=357085110",
-      "mapper_name":"Verifyy",
-      "mapper_steamid64":"76561197995535364"
-   },
-   {
-      "id":"391",
-      "name":"kz_jg_ditch",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=367347758",
-      "mapper_name":"ticK!",
-      "mapper_steamid64":"76561198171545305"
-   },
-   {
-      "id":"754",
-      "name":"kz_johndoe",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2015357272",
-      "mapper_name":"Bolo",
-      "mapper_steamid64":"76561198297512910"
-   },
-   {
-      "id":"392",
-      "name":"kz_jump_n_run",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=629040765",
-      "mapper_name":"Smex",
-      "mapper_steamid64":"76561197961558198"
-   },
-   {
-      "id":"889",
-      "name":"kz_kat_colorblind",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2277557067",
-      "mapper_name":"katz, rush2sk8",
-      "mapper_steamid64":"76561198067576863, 76561198082904691"
-   },
-   {
-      "id":"952",
-      "name":"kz_kiwiexultation",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2415258457",
-      "mapper_name":"Kiwi",
-      "mapper_steamid64":"76561198077353609"
-   },
-   {
-      "id":"844",
-      "name":"kz_kiwitech",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2229046768",
-      "mapper_name":"Kiwi",
-      "mapper_steamid64":"76561198077353609"
-   },
-   {
-      "id":"951",
-      "name":"kz_kiwiterror",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2413286682",
-      "mapper_name":"Kiwi",
-      "mapper_steamid64":"76561198077353609"
-   },
-   {
-      "id":"932",
-      "name":"kz_kiwi_cod",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2256093157",
-      "mapper_name":"Kiwi, CoD",
-      "mapper_steamid64":"76561198077353609, 76561198846255522"
-   },
-   {
-      "id":"800",
-      "name":"kz_kohze_sucks",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2130097882",
-      "mapper_name":"Krushed",
-      "mapper_steamid64":"76561197966948458"
-   },
-   {
-      "id":"394",
-      "name":"kz_kzinga_fixed",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=455178914",
-      "mapper_name":"finckelton",
-      "mapper_steamid64":"76561198039388458"
-   },
-   {
-      "id":"762",
-      "name":"kz_kzra_bars",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1901874741",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"763",
-      "name":"kz_kzra_cliffy",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1912922798",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"771",
-      "name":"kz_kzra_hohum",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1877338856",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"682",
-      "name":"kz_kzra_morath",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1761949860",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"793",
-      "name":"kz_kzra_oddland",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2105252723",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"669",
-      "name":"kz_kzra_shortclimb_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1753701773",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"699",
-      "name":"kz_kzra_skaxis",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1846345249",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"700",
-      "name":"kz_kzra_slidely",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1816052873",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"887",
-      "name":"kz_kzra_slidepuf",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1824161798",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"851",
-      "name":"kz_kzra_stoneishbhop",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207370784",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"701",
-      "name":"kz_kzra_voovblock",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1795477339",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"685",
-      "name":"kz_kzra_whitesquare",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1793270481",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"772",
-      "name":"kz_kzro_brickstgrass_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2235348857",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"866",
-      "name":"kz_kzro_bronea",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2237646194",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"808",
-      "name":"kz_kzro_gohome",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2117028264",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"867",
-      "name":"kz_kzro_hardvalley",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215405289",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"786",
-      "name":"kz_kzro_mountainbhop",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2118958853",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"906",
-      "name":"kz_kzro_mountainsein",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2207874525",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"896",
-      "name":"kz_kzro_mountainsnow",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2230533130",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"883",
-      "name":"kz_kzro_slidesmear",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2239093087",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"845",
-      "name":"kz_kzro_sunmountainset",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2222540470",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"395",
-      "name":"kz_kzse_aztectemple",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=302894093",
-      "mapper_name":"Sinful",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"791",
-      "name":"kz_ladderall",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2124189658",
-      "mapper_name":"Cou",
-      "mapper_steamid64":"76561198007928944"
-   },
-   {
-      "id":"833",
-      "name":"kz_ladderdespair",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2191784508",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"755",
-      "name":"kz_ladderhell_fix",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2034623068",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"396",
-      "name":"kz_lavablock_global",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406054554",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"900",
-      "name":"kz_layercake",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2255773578",
-      "mapper_name":"Downie2K",
-      "mapper_steamid64":"76561197981037626"
-   },
-   {
-      "id":"788",
-      "name":"kz_lazy",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2105506029",
-      "mapper_name":"Michael, Haakz",
-      "mapper_steamid64":"76561198004229810, 76561197990350366"
-   },
-   {
-      "id":"397",
-      "name":"kz_lego",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=351298054",
-      "mapper_name":"DutchSnowman",
-      "mapper_steamid64":"76561198027507070"
-   },
-   {
-      "id":"398",
-      "name":"kz_lego_two_redux_v3",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=515550870",
-      "mapper_name":"DutchSnowman",
-      "mapper_steamid64":"76561198027507070"
-   },
-   {
-      "id":"399",
-      "name":"kz_levels",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=635973918",
-      "mapper_name":"Jurkelis",
-      "mapper_steamid64":"76561198071655291"
-   },
-   {
-      "id":"400",
-      "name":"kz_life_final",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=683576131",
-      "mapper_name":"Chaosangel",
-      "mapper_steamid64":"76561198078333036"
-   },
-   {
-      "id":"721",
-      "name":"kz_lionheart",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1805200433",
-      "mapper_name":"iBUYFL0WER Birgit, nutsdoodle",
-      "mapper_steamid64":"76561198078014747, 76561198150143219"
-   },
-   {
-      "id":"819",
-      "name":"kz_list_gnida_v2",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=630032870",
-      "mapper_name":"DeadRote",
-      "mapper_steamid64":"76561198034507626"
-   },
-   {
-      "id":"401",
-      "name":"kz_littlerock_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156067138",
-      "mapper_name":"Surion"
-   },
-   {
-      "id":"917",
-      "name":"kz_loathe",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1961922598",
-      "mapper_name":"JJ",
-      "mapper_steamid64":"76561198167125526"
-   },
-   {
-      "id":"842",
-      "name":"kz_longjumps_easy",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
-      "mapper_name":"ExtremerZ"
-      "mapper_steamid64":"76561197965479288"
-   },
-   {
-      "id":"604",
-      "name":"kz_longjumps_space",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=637925784",
-      "mapper_name":"JONY, CyclO",
-      "mapper_steamid64":"76561198000829729, 76561198024466262"
-   },
-   {
-      "id":"876",
-      "name":"kz_lookout",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2245294640",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"644",
-      "name":"kz_lost_marketplace_gfix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939577604",
-      "mapper_name":"JONY, Rosquilla Guy",
-      "mapper_steamid64":"76561198000829729, 76561198102575797"
-   },
-   {
-      "id":"933",
-      "name":"kz_lovely",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2227118054",
-      "mapper_name":"makis",
-      "mapper_steamid64":"76561198201492663"
-   },
-   {
-      "id":"403",
-      "name":"kz_lume",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=717341154",
-      "mapper_name":"VVoodchip",
-      "mapper_steamid64":"76561198061948302"
-   },
-   {
-      "id":"404",
-      "name":"kz_luonto",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1102578759",
-      "mapper_name":"sBlisss, GameChaos",
-      "mapper_steamid64":"null, 76561198165203332"
-   },
-   {
-      "id":"938",
-      "name":"kz_luv_less",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2350173887",
-      "mapper_name":"J3wDice",
-      "mapper_steamid64":"76561198208729343"
-   },
-   {
-      "id":"405",
-      "name":"kz_mac",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=336084898",
-      "mapper_name":"mac",
-      "mapper_steamid64":"76561198056335207"
-   },
-   {
-      "id":"743",
-      "name":"kz_machinery",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1921655838",
-      "mapper_name":"iBUYFL0WER Birgit",
-      "mapper_steamid64":"76561198078014747"
-   },
-   {
-      "id":"406",
-      "name":"kz_magus",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=401088222",
-      "mapper_name":"Doveen",
-      "mapper_steamid64":"76561198033299991"
-   },
-   {
-      "id":"756",
-      "name":"kz_malignom_short",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1962044626",
-      "mapper_name":"jens",
-      "mapper_steamid64":"76561198110357840"
-   },
-   {
-      "id":"942",
-      "name":"kz_mandelbrot",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259048305",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"407",
-      "name":"kz_man_everest_go_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1098716930",
-      "mapper_name":"Kreedz, Spherix, GnagarN",
-      "mapper_steamid64":"76561197997103423, null, 76561198009902429"
-   },
-   {
-      "id":"408",
-      "name":"kz_marblewalls_fixed",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=391298485",
-      "mapper_name":"Aaron"
-   },
-   {
-      "id":"587",
-      "name":"kz_matilda_np",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1442293882",
-      "mapper_name":"Matilda",
-      "mapper_steamid64":"76561197999312081"
-   },
-   {
-      "id":"670",
-      "name":"kz_meander",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1657680583",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"410",
-      "name":"kz_megabhop_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667953480",
-      "mapper_name":"N1ghtFoX, Chuli"
-   },
-   {
-      "id":"411",
-      "name":"kz_megalodon",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1184142056",
-      "mapper_name":"nykaN",
-      "mapper_steamid64":"76561198014491259"
-   },
-   {
-      "id":"868",
-      "name":"kz_memento",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2226685570",
-      "mapper_name":"Downie2K",
-      "mapper_steamid64":"76561197981037626"
-   },
-   {
-      "id":"654",
-      "name":"kz_mescaline_f",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1704411752",
-      "mapper_name":"mark",
-      "mapper_steamid64":"76561198045869085"
-   },
-   {
-      "id":"412",
-      "name":"kz_metalrun_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406054781",
-      "mapper_name":"Witchhowl",
-      "mapper_steamid64":"76561198027343851"
-   },
-   {
-      "id":"903",
-      "name":"kz_micropenis",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2274722735",
-      "mapper_name":"Cou ",
-      "mapper_steamid64":"76561198007928944"
-   },
-   {
-      "id":"905",
-      "name":"kz_microwave",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2259353310",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"824",
-      "name":"kz_mieszaneuczucia",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2168009794",
-      "mapper_name":"nutsdoodle",
-      "mapper_steamid64":"76561198150143219"
-   },
-   {
-      "id":"413",
-      "name":"kz_mike_v4",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352438024",
-      "mapper_name":"MikeChas",
-      "mapper_steamid64":"76561198033854242"
-   },
-   {
-      "id":"773",
-      "name":"kz_milehigh",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2081487108",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"414",
-      "name":"kz_minimalism",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=784686492",
-      "mapper_name":"badges, ρ",
-      "mapper_steamid64":"76561197983438223, 76561198002830622"
-   },
-   {
-      "id":"605",
-      "name":"kz_minimal_combo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=688173479",
-      "mapper_name":"UNKNOWN:(",
-      "mapper_steamid64":"76561198140867695"
-   },
-   {
-      "id":"415",
-      "name":"kz_minimountain_f",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1819270715",
-      "mapper_name":"finckelton",
-      "mapper_steamid64":"76561198039388458"
-   },
-   {
-      "id":"588",
-      "name":"kz_modernvomit",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1387010348",
-      "mapper_name":"evanstep",
-      "mapper_steamid64":"76561198067339661"
-   },
-   {
-      "id":"416",
-      "name":"kz_module",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=531121171",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"417",
-      "name":"kz_moonlight",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=653958895",
-      "mapper_name":"jurkelis",
-      "mapper_steamid64":"76561198071655291"
-   },
-   {
-      "id":"625",
-      "name":"kz_moorerutan",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1538928192",
-      "mapper_name":"Rumme",
-      "mapper_steamid64":"76561198112936613"
-   },
-   {
-      "id":"418",
-      "name":"kz_morebricks_msq",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=624692501",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"571",
-      "name":"kz_morestairs_msq",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1370543054",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"807",
-      "name":"kz_motivated",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=504145143",
-      "mapper_name":"Drinka",
-      "mapper_steamid64":"76561198100929785"
-   },
-   {
-      "id":"419",
-      "name":"kz_msp_comatose",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418089472",
-      "mapper_name":"Pebi, masque, skitty",
-      "mapper_steamid64":"76561198077530872, 76561197979436335, 76561198031452487"
-   },
-   {
-      "id":"875",
-      "name":"kz_mushrruption_v8",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2280643029",
-      "mapper_name":"Sehk",
-      "mapper_steamid64":"76561198037724970"
-   },
-   {
-      "id":"744",
-      "name":"kz_mz",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1988044539",
-      "mapper_name":"Zach47, nykaN",
-      "mapper_steamid64":"76561197983014207, 76561198014491259"
-   },
-   {
-      "id":"784",
-      "name":"kz_nassau",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2096632231",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"420",
-      "name":"kz_natureblock_scte",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2111399696",
-      "mapper_name":"Chichin, Pr3da",
-      "mapper_steamid64":"76561197991555455, 76561198021246024"
-   },
-   {
-      "id":"421",
-      "name":"kz_nature_csgo",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080089",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"904",
-      "name":"kz_nb_final",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2246885072",
-      "mapper_name":"Da0lang",
-      "mapper_steamid64":"76561198814294487"
-   },
-   {
-      "id":"947",
-      "name":"kz_neoncity_z",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2260637520",
-      "mapper_name":"_Z",
-      "mapper_steamid64":"76561198365448333"
-   },
-   {
-      "id":"422",
-      "name":"kz_neon_portal",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=427001332",
-      "mapper_name":"TherapySession",
-      "mapper_steamid64":"76561198012265008"
-   },
-   {
-      "id":"802",
-      "name":"kz_nieh",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2128027875",
-      "mapper_name":"S1lic",
-      "mapper_steamid64":"76561198874435443"
-   },
-   {
-      "id":"810",
-      "name":"kz_nightcastle",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2143021601",
-      "mapper_name":"Petter",
-      "mapper_steamid64":"76561198416084167"
-   },
-   {
-      "id":"423",
-      "name":"kz_nightfall",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2073457452",
-      "mapper_name":"Pebi, Danvari",
-      "mapper_steamid64":"76561198077530872, 76561198038388449"
-   },
-   {
-      "id":"424",
-      "name":"kz_nightmare_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=386548794",
-      "mapper_name":"m-tet"
-   },
-   {
-      "id":"698",
-      "name":"kz_nix_od",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1773124335",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"809",
-      "name":"kz_noobfort",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2128202621",
-      "mapper_name":"Lux",
-      "mapper_steamid64":"76561198055771460"
-   },
-   {
-      "id":"940",
-      "name":"kz_northkorean_censorship",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2382813554",
-      "mapper_name":"rov",
-      "mapper_steamid64":"76561198132236283"
-   },
-   {
-      "id":"425",
-      "name":"kz_nyc_v1",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
-      "mapper_name":"Vypur",
-      "mapper_steamid64":"76561198027553039"
-   },
-   {
-      "id":"606",
-      "name":"kz_nymph",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
-      "mapper_name":"Cyclo",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"426",
-      "name":"kz_oasis",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=650371940",
-      "mapper_name":"Pebi",
-      "mapper_steamid64":"76561198077530872"
-   },
-   {
-      "id":"427",
-      "name":"kz_obsidian",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418449564",
-      "mapper_name":"SinFuL",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"723",
-      "name":"kz_okaychamp",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1881193335",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"428",
-      "name":"kz_oldstuff",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=491404667",
-      "mapper_name":"DannyE",
-      "mapper_steamid64":"76561198178232629"
-   },
-   {
-      "id":"572",
-      "name":"kz_oloramasa",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1282978596",
-      "mapper_name":"Alves",
-      "mapper_steamid64":"76561198063573203"
-   },
-   {
-      "id":"429",
-      "name":"kz_olympus",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=171110248",
-      "mapper_name":"KingGambit",
-      "mapper_steamid64":"76561198023829871"
-   },
-   {
-      "id":"430",
-      "name":"kz_ominous2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=782868988",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"655",
-      "name":"kz_openspace",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1685172182",
-      "mapper_name":"Lazovsky",
-      "mapper_steamid64":"76561198003859123"
-   },
-   {
-      "id":"431",
-      "name":"kz_orangejuice_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=813837226",
-      "mapper_name":"masque, DanZay",
-      "mapper_steamid64":"76561197979436335, 76561197989817982"
-   },
-   {
-      "id":"432",
-      "name":"kz_orbolution_v2",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=644224500",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"795",
-      "name":"kz_otakuroom",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2106385628",
-      "mapper_name":"GemaYue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"433",
-      "name":"kz_overgrowth",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1092513702",
-      "mapper_name":"stz",
-      "mapper_steamid64":"76561198261992780"
-   },
-   {
-      "id":"626",
-      "name":"kz_overjoyed",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1465826915",
-      "mapper_name":"Gamzky",
-      "mapper_steamid64":"76561198262673963"
-   },
-   {
-      "id":"829",
-      "name":"kz_owtetad",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2190664967",
-      "mapper_name":"Krushed",
-      "mapper_steamid64":"76561197966948458"
-   },
-   {
-      "id":"724",
-      "name":"kz_p1",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1684028086",
-      "mapper_name":"JONY",
-      "mapper_steamid64":"76561198000829729"
-   },
-   {
-      "id":"676",
-      "name":"kz_paintball_tv_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1717536029",
-      "mapper_name":"pb, victoria248",
-      "mapper_steamid64":"76561197971221508, 76561198026839022"
-   },
-   {
-      "id":"774",
-      "name":"kz_pamxul_wip",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2085124881",
-      "mapper_name":"Lux",
-      "mapper_steamid64":"76561198055771460"
-   },
-   {
-      "id":"434",
-      "name":"kz_pantheism_p02",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519500089",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"435",
-      "name":"kz_paradise",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=636580309",
-      "mapper_name":"pr3da",
-      "mapper_steamid64":"76561198021246024"
-   },
-   {
-      "id":"436",
-      "name":"kz_peak_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419054557",
-      "mapper_name":"PHQ",
-      "mapper_steamid64":"76561197981825703"
-   },
-   {
-      "id":"934",
-      "name":"kz_pendulum",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1937590263",
-      "mapper_name":"JJ",
-      "mapper_steamid64":"76561198167125526"
-   },
-   {
-      "id":"931",
-      "name":"kz_perfunctory",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2253427267",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"437",
-      "name":"kz_phamous",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=404322417",
-      "mapper_name":"Phinx",
-      "mapper_steamid64":"76561198023207107"
-   },
-   {
-      "id":"438",
-      "name":"kz_pharaoh_csgo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=377402121",
-      "mapper_name":"Daniel_Lyness"
-   },
-   {
-      "id":"859",
-      "name":"kz_pharos_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2274441302",
-      "mapper_name":"Crixxzi",
-      "mapper_steamid64":"76561198046307458"
-   },
-   {
-      "id":"439",
-      "name":"kz_phaztec",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399418936",
-      "mapper_name":"Phinx",
-      "mapper_steamid64":"76561198023207107"
-   },
-   {
-      "id":"440",
-      "name":"kz_pianoclimb_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=230274161",
-      "mapper_name":"DyleT2"
-   },
-   {
-      "id":"441",
-      "name":"kz_pineforest_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=778556068",
-      "mapper_name":"Lillen",
-      "mapper_steamid64":"76561198077858937"
-   },
-   {
-      "id":"442",
-      "name":"kz_piranha",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1185869594",
-      "mapper_name":"GameChaos",
-      "mapper_steamid64":"76561198165203332"
-   },
-   {
-      "id":"443",
-      "name":"kz_pixelrun_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=782827606",
-      "mapper_name":"TheWhaleMan",
-      "mapper_steamid64":"76561198064508818"
-   },
-   {
-      "id":"444",
-      "name":"kz_plains",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=747076334",
-      "mapper_name":"Shire",
-      "mapper_steamid64":"76561198104341799"
-   },
-   {
-      "id":"445",
-      "name":"kz_pollution",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=633854360",
-      "mapper_name":"pr3da",
-      "mapper_steamid64":"76561198021246024"
-   },
-   {
-      "id":"656",
-      "name":"kz_porridge",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1533494110",
-      "mapper_name":"Diesel",
-      "mapper_steamid64":"76561198099241969"
-   },
-   {
-      "id":"806",
-      "name":"kz_portal_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2208043488",
-      "mapper_name":"epic",
-      "mapper_steamid64":"76561198028317188"
-   },
-   {
-      "id":"607",
-      "name":"kz_prekeeper",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1535314044",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"446",
-      "name":"kz_prima",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=896453952",
-      "mapper_name":"Cobrex",
-      "mapper_steamid64":"76561198060634245"
-   },
-   {
-      "id":"447",
-      "name":"kz_prismus",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080437",
-      "mapper_name":"Deepus",
-      "mapper_steamid64":"76561197976153012"
-   },
-   {
-      "id":"946",
-      "name":"kz_procrastination_f",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2370566385",
-      "mapper_name":"lenny",
-      "mapper_steamid64":"76561198145963095"
-   },
-   {
-      "id":"956",
-      "name":"kz_progressive",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2421910892",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"448",
-      "name":"kz_project",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=656536301",
-      "mapper_name":"Isk",
-      "mapper_steamid64":"76561198195095059"
-   },
-   {
-      "id":"782",
-      "name":"kz_prolific",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2091137824",
-      "mapper_name":"jord",
-      "mapper_steamid64":"76561198066952826"
-   },
-   {
-      "id":"608",
-      "name":"kz_prototype",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=520364028",
-      "mapper_name":"Smex",
-      "mapper_steamid64":"76561197961558198"
-   },
-   {
-      "id":"910",
-      "name":"kz_psychosomatic",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2422388657",
-      "mapper_name":"Plastyc, Raunox",
-      "mapper_steamid64":"76561199024218227, 76561198254175551"
-   },
-   {
-      "id":"790",
-      "name":"kz_psyk",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030706198",
-      "mapper_name":"G O A",
-      "mapper_steamid64":"76561197990887735"
-   },
-   {
-      "id":"449",
-      "name":"kz_psytime_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=623887144",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"745",
-      "name":"kz_purgatory",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1943903062",
-      "mapper_name":"Amber, htc, Rebmaa",
-      "mapper_steamid64":"null, null, 76561197970776455 "
-   },
-   {
-      "id":"450",
-      "name":"kz_quadrablock",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068013",
-      "mapper_name":"Pix"
-   },
-   {
-      "id":"451",
-      "name":"kz_quadrant_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1369715256",
-      "mapper_name":"River",
-      "mapper_steamid64":"76561198054436805"
-   },
-   {
-      "id":"452",
-      "name":"kz_quick7_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=562956061",
-      "mapper_name":"MurrayAU",
-      "mapper_steamid64":"76561198019551123"
-   },
-   {
-      "id":"620",
-      "name":"kz_quicksand",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1579335691",
-      "mapper_name":"Sisms(?)",
-      "mapper_steamid64":"76561198166999579"
-   },
-   {
-      "id":"453",
-      "name":"kz_quickshot",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=437195052",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"454",
-      "name":"kz_quixotic",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=581076797",
-      "mapper_name":"Matilda",
-      "mapper_steamid64":"76561197999312081"
-   },
-   {
-      "id":"455",
-      "name":"kz_railings",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=301219724",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"456",
-      "name":"kz_rainrun_kn_f",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=509126081",
-      "mapper_name":"Knove",
-      "mapper_steamid64":"76561198109227174"
-   },
-   {
-      "id":"457",
-      "name":"kz_rcn_impermanence",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1235824121",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"458",
-      "name":"kz_rcn_optimisery",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1228153185",
-      "mapper_name":"archon",
-      "mapper_steamid64":"76561198034601835"
-   },
-   {
-      "id":"459",
-      "name":"kz_reach_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=421596934",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"813",
-      "name":"kz_rectangle",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2127477792",
-      "mapper_name":"Michael",
-      "mapper_steamid64":"76561198004229810"
-   },
-   {
-      "id":"460",
-      "name":"kz_redemption_csgo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=269756340",
-      "mapper_name":"Tipii, fl0w",
-      "mapper_steamid64":"null, 76561197991750093"
-   },
-   {
-      "id":"461",
-      "name":"kz_redline",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
-      "mapper_name":"ExtremerZ"
-      "mapper_steamid64":"76561197965479288"
-   },
-   {
-      "id":"764",
-      "name":"kz_refract",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2054929131",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"901",
-      "name":"kz_refuge",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2260756501",
-      "mapper_name":"nykaN",
-      "mapper_steamid64":"76561198014491259"
-   },
-   {
-      "id":"462",
-      "name":"kz_remedy_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=458847658",
-      "mapper_name":"Piu",
-      "mapper_steamid64":"76561198014009703"
-   },
-   {
-      "id":"688",
-      "name":"kz_research",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1233676255",
-      "mapper_name":"Fafnir",
-      "mapper_steamid64":"76561198072210646"
-   },
-   {
-      "id":"463",
-      "name":"kz_retribution_v2_final",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=535037159",
-      "mapper_name":"Flux",
-      "mapper_steamid64":"76561198040691989"
-   },
-   {
-      "id":"464",
-      "name":"kz_return",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=610279618",
-      "mapper_name":"DanZay",
-      "mapper_steamid64":"76561197989817982"
-   },
-   {
-      "id":"899",
-      "name":"kz_reverse",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2261076218",
-      "mapper_name":"Temmie, Da0lang",
-      "mapper_steamid64":"76561198137502865, 76561198814294487"
-   },
-   {
-      "id":"628",
-      "name":"kz_rise",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=661509726",
-      "mapper_name":"schm0ftie",
-      "mapper_steamid64":"76561197983561860"
-   },
-   {
-      "id":"465",
-      "name":"kz_rockclimb",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=294354248",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"466",
-      "name":"kz_rockjungle_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=706798826",
-      "mapper_name":"GWB",
-      "mapper_steamid64":"76561198010817168"
-   },
-   {
-      "id":"467",
-      "name":"kz_rocks_global",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1728344964",
-      "mapper_name":"keyuu",
-      "mapper_steamid64":"76561198003202977"
-   },
-   {
-      "id":"765",
-      "name":"kz_roman",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2071759440",
-      "mapper_name":"Ori",
-      "mapper_steamid64":"76561198157565655"
-   },
-   {
-      "id":"874",
-      "name":"kz_rompenutrias_asheglado",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1528890944",
-      "mapper_name":"Shendal",
-      "mapper_steamid64":"76561198225775664"
-   },
-   {
-      "id":"555",
-      "name":"kz_rumzor",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1157701765",
-      "mapper_name":"Rumme",
-      "mapper_steamid64":"76561198112936613"
-   },
-   {
-      "id":"852",
-      "name":"kz_rush2sk8",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2212481749",
-      "mapper_name":"rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"919",
-      "name":"kz_rush2suck",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2346899830",
-      "mapper_name":"Krushed, stz, nopey",
-      "mapper_steamid64":"76561197966948458, 76561198261992780, 76561198401447544"
-   },
-   {
-      "id":"468",
-      "name":"kz_sanctuary",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387095066",
-      "mapper_name":"Ace"
-   },
-   {
-      "id":"469",
-      "name":"kz_sandstone_mq",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=318255698",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"470",
-      "name":"kz_sandstorm_ez",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=399829430",
-      "mapper_name":"DropInMilk",
-      "mapper_steamid64":"76561198033385282"
-   },
-   {
-      "id":"471",
-      "name":"kz_sandyhill_hoc",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068273",
-      "mapper_name":"SinFuL",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"886",
-      "name":"kz_scum",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2262738254",
-      "mapper_name":"dillon",
-      "mapper_steamid64":"76561198120868833"
-   },
-   {
-      "id":"472",
-      "name":"kz_sendhelp_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=414276208",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"473",
-      "name":"kz_serenity",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=564068433",
-      "mapper_name":"UnderhellCS",
-      "mapper_steamid64":"76561198071769233"
-   },
-   {
-      "id":"877",
-      "name":"kz_shaft_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2228832434",
-      "mapper_name":"Beikenost",
-      "mapper_steamid64":"76561198117002699"
-   },
-   {
-      "id":"671",
-      "name":"kz_shell",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1640657838",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"766",
-      "name":"kz_shortcut_tx",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2059971679",
-      "mapper_name":"Elem",
-      "mapper_steamid64":"76561199023877609"
-   },
-   {
-      "id":"475",
-      "name":"kz_signs_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=570362293",
-      "mapper_name":"Guta",
-      "mapper_steamid64":"76561198000799482"
-   },
-   {
-      "id":"726",
-      "name":"kz_simplejourney",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1842969271",
-      "mapper_name":"ρ",
-      "mapper_steamid64":"76561198002830622"
-   },
-   {
-      "id":"725",
-      "name":"kz_simple_sp",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1995891136",
-      "mapper_name":"saicho91",
-      "mapper_steamid64":"76561197995141366"
-   },
-   {
-      "id":"476",
-      "name":"kz_simplicity_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=596881274",
-      "mapper_name":"Netcode",
-      "mapper_steamid64":"76561198083399596"
-   },
-   {
-      "id":"836",
-      "name":"kz_skybridge",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2170006392",
-      "mapper_name":"Aquilla",
-      "mapper_steamid64":"76561198337861414"
-   },
-   {
-      "id":"477",
-      "name":"kz_skyhotel",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=508852626",
-      "mapper_name":"Flux",
-      "mapper_steamid64":"76561198040691989"
-   },
-   {
-      "id":"556",
-      "name":"kz_sky_lake",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1298788457",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"479",
-      "name":"kz_slate",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=871544753",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"702",
-      "name":"kz_slidebober",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1825259311",
-      "mapper_name":"Slyph"
-   },
-   {
-      "id":"746",
-      "name":"kz_slidemap_ez_v2_rmk_final",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2421819231",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"949",
-      "name":"kz_slide_concrete",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2356803567",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"775",
-      "name":"kz_slide_deee",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2016401059",
-      "mapper_name":"Dima",
-      "mapper_steamid64":"76561198198062889"
-   },
-   {
-      "id":"632",
-      "name":"kz_slide_dydanhomon",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1586833508",
-      "mapper_name":"dydka",
-      "mapper_steamid64":"76561198010747369"
-   },
-   {
-      "id":"797",
-      "name":"kz_slide_kissa",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2081916777",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"757",
-      "name":"kz_slide_koira",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2010190400",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"909",
-      "name":"kz_slide_pallokala",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2288332530",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"890",
-      "name":"kz_slide_pisauva",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2251257791",
-      "mapper_name":"Shendal",
-      "mapper_steamid64":"76561198225775664"
-   },
-   {
-      "id":"703",
-      "name":"kz_slide_purple_x",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1842176999",
-      "mapper_name":"Kirman, PreFect"
-   },
-   {
-      "id":"945",
-      "name":"kz_slide_rawr_xdeee",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2190416060",
-      "mapper_name":"Dima",
-      "mapper_steamid64":"76561198198062889"
-   },
-   {
-      "id":"727",
-      "name":"kz_slide_rovod",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2418190102",
-      "mapper_name":"rov, Overdose",
-      "mapper_steamid64":"76561198132236283, 76561198142809343"
-   },
-   {
-      "id":"609",
-      "name":"kz_slide_svn_extreme",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1545821165",
-      "mapper_name":"SilverNinja"
-   },
-   {
-      "id":"704",
-      "name":"kz_slide_svn_temple",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1866612534",
-      "mapper_name":"SilverNinja"
-   },
-   {
-      "id":"821",
-      "name":"kz_slide_vaahtera",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2184236748",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"818",
-      "name":"kz_slowrun_global_fix",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1355920261",
-      "mapper_name":"cnc3ep1",
-      "mapper_steamid64":"76561198143741877"
-   },
-   {
-      "id":"672",
-      "name":"kz_slumpfrageous",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1741709684",
-      "mapper_name":"victoria248",
-      "mapper_steamid64":"76561198026839022"
-   },
-   {
-      "id":"789",
-      "name":"kz_smallcastle",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2025955407",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"573",
-      "name":"kz_smallmap",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1339159026",
-      "mapper_name":"Samuel",
-      "mapper_steamid64":"76561198191875674"
-   },
-   {
-      "id":"480",
-      "name":"kz_snowman_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=337956674",
-      "mapper_name":"DutchSnowman",
-      "mapper_steamid64":"76561198027507070"
-   },
-   {
-      "id":"481",
-      "name":"kz_solidarity_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580922647",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"955",
-      "name":"kz_sonder",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2385596806",
-      "mapper_name":"dillon",
-      "mapper_steamid64":"76561198120868833"
-   },
-   {
-      "id":"853",
-      "name":"kz_sp1_bloodyljs",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224266412",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"880",
-      "name":"kz_sp1_candles",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2243496277",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"912",
-      "name":"kz_sp1_castaway",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2283294555",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"935",
-      "name":"kz_sp1_hallwaybhop",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2305555371",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"854",
-      "name":"kz_sp1_hiragana",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2210394074",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"948",
-      "name":"kz_sp1_katakana",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2381711985",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"927",
-      "name":"kz_sp1_perf2win",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2322149205",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"861",
-      "name":"kz_spaceladders_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2229077733",
-      "mapper_name":"Cybur",
-      "mapper_steamid64":"76561198062384407"
-   },
-   {
-      "id":"557",
-      "name":"kz_spacemario_h",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685184665",
-      "mapper_name":"Eightb0",
-      "mapper_steamid64":"76561198010762038"
-   },
-   {
-      "id":"482",
-      "name":"kz_spacus",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=522846216",
-      "mapper_name":"Deepus, Hawk",
-      "mapper_steamid64":"76561197976153012, 76561198218057127"
-   },
-   {
-      "id":"846",
-      "name":"kz_spire",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2205432051",
-      "mapper_name":"RZL, Fnugz",
-      "mapper_steamid64":"76561197985774978, 76561198012891563"
-   },
-   {
-      "id":"483",
-      "name":"kz_spiritblockv2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068550",
-      "mapper_name":"jYue, SoUlFaThEr",
-      "mapper_steamid64":"null, 76561197965266419"
-   },
-   {
-      "id":"812",
-      "name":"kz_splopkopsc_loverick",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1126798978",
-      "mapper_name":"Steez",
-      "mapper_steamid64":"76561198261992780"
-   },
-   {
-      "id":"484",
-      "name":"kz_spores_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=418447771",
-      "mapper_name":"G O A",
-      "mapper_steamid64":"76561197990887735"
-   },
-   {
-      "id":"485",
-      "name":"kz_sqrdsucks",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=870091342",
-      "mapper_name":"Krushed",
-      "mapper_steamid64":"76561197966948458"
-   },
-   {
-      "id":"855",
-      "name":"kz_stepblock",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2221286065",
-      "mapper_name":"Crixxzi",
-      "mapper_steamid64":"76561198046307458"
-   },
-   {
-      "id":"954",
-      "name":"kz_stepup",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2378820376",
-      "mapper_name":"Emzatin",
-      "mapper_steamid64":"76561198393292046"
-   },
-   {
-      "id":"486",
-      "name":"kz_strafehop_fix",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=727970399",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"487",
-      "name":"kz_stranded",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=881021394",
-      "mapper_name":"nykaN, coach",
-      "mapper_steamid64":"76561198014491259, 76561197969061501"
-   },
-   {
-      "id":"488",
-      "name":"kz_streetblock_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
-      "mapper_name":"s0lid"
-      "mapper_steamid64":"76561197980460370"
-   },
-   {
-      "id":"856",
-      "name":"kz_structures",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=613750240",
-      "mapper_name":"colony",
-      "mapper_steamid64":"76561198012716104"
-   },
-   {
-      "id":"489",
-      "name":"kz_strun_mq",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=522194087",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"490",
-      "name":"kz_stuff_final",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=397542914",
-      "mapper_name":"Pebi",
-      "mapper_steamid64":"76561198077530872"
-   },
-   {
-      "id":"491",
-      "name":"kz_sukblock_v2_fixed",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=511719435",
-      "mapper_name":"Suck' TearZ"
-   },
-   {
-      "id":"492",
-      "name":"kz_summercliff2_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
-      "mapper_name":"s0liD"
-      "mapper_steamid64":"76561197980460370"
-   },
-   {
-      "id":"776",
-      "name":"kz_suomi",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030976502",
-      "mapper_name":"tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"915",
-      "name":"kz_superstructure",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2252104070",
-      "mapper_name":"_max",
-      "mapper_steamid64":"76561198083065598"
-   },
-   {
-      "id":"944",
-      "name":"kz_surf_ace",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2366218120",
-      "mapper_name":"Dima, Juxtapo",
-      "mapper_steamid64":"76561198198062889, 76561197982874432"
-   },
-   {
-      "id":"705",
-      "name":"kz_surf_blue",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1777661554",
-      "mapper_name":"CyclO",
-      "mapper_steamid64":"76561198024466262"
-   },
-   {
-      "id":"494",
-      "name":"kz_surf_kim_hana_gl",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=846934364",
-      "mapper_name":"Gull",
-      "mapper_steamid64":"76561198137589262"
-   },
-   {
-      "id":"495",
-      "name":"kz_swamped_v3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=737262158",
-      "mapper_name":"Orbit",
-      "mapper_steamid64":"76561198057269402"
-   },
-   {
-      "id":"496",
-      "name":"kz_symbiosis_final",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=407752167",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"835",
-      "name":"kz_symmetry",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2169425331",
-      "mapper_name":"Lameskydiver",
-      "mapper_steamid64":"76561198082880577"
-   },
-   {
-      "id":"219",
-      "name":"kz_synergy_ez",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030361679",
-      "mapper_name":"pLANE, fl0w",
-      "mapper_steamid64":"76561197969425557, 76561197991750093"
-   },
-   {
-      "id":"220",
-      "name":"kz_synergy_x",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2030360282",
-      "mapper_name":"pLANE, fl0w",
-      "mapper_steamid64":"76561197969425557, 76561197991750093"
-   },
-   {
-      "id":"497",
-      "name":"kz_synthesis_v2",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=524273901",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"498",
-      "name":"kz_sz_goldenbean",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=279111456",
-      "mapper_name":"SinFuL",
-      "mapper_steamid64":"76561197970838363"
-   },
-   {
-      "id":"500",
-      "name":"kz_talltreeforest_v3",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=353767057",
-      "mapper_name":"Vypur",
-      "mapper_steamid64":"76561198027553039"
-   },
-   {
-      "id":"501",
-      "name":"kz_talmaniac",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=875664112",
-      "mapper_name":"AREDONE, GameChaos",
-      "mapper_steamid64":"76561198082306844, 76561198165203332"
-   },
-   {
-      "id":"857",
-      "name":"kz_technical_difficulties",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215677224",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"637",
-      "name":"kz_techtonic_v2_ldr",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1679345238",
-      "mapper_name":"iBUYFL0WER Birgit",
-      "mapper_steamid64":"76561198078014747"
-   },
-   {
-      "id":"502",
-      "name":"kz_terablock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=269563440",
-      "mapper_name":"SinFul, fl0w",
-      "mapper_steamid64":"null, 76561197991750093"
-   },
-   {
-      "id":"816",
-      "name":"kz_theaquila",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2183036742",
-      "mapper_name":"Aquilla",
-      "mapper_steamid64":"76561198337861414"
-   },
-   {
-      "id":"610",
-      "name":"kz_thinkblock",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1543810415",
-      "mapper_name":"xq, GameChaos",
-      "mapper_steamid64":"76561198094382485, 76561198165203332"
-   },
-   {
-      "id":"748",
-      "name":"kz_thrombosis",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1803151428",
-      "mapper_name":"rov",
-      "mapper_steamid64":"76561198132236283"
-   },
-   {
-      "id":"503",
-      "name":"kz_timescape_zero",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=937263331",
-      "mapper_name":"Blixx",
-      "mapper_steamid64":"76561198017413484"
-   },
-   {
-      "id":"504",
-      "name":"kz_tomb_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1099232235",
-      "mapper_name":"MoHaX_cm"
-   },
-   {
-      "id":"505",
-      "name":"kz_toonadventure_go",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156068846",
-      "mapper_name":"PHQ",
-      "mapper_steamid64":"76561197981825703"
-   },
-   {
-      "id":"506",
-      "name":"kz_toonrun_final",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=375234842",
-      "mapper_name":"BigBangQuint"
-   },
-   {
-      "id":"673",
-      "name":"kz_toughluck_fix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1740708159",
-      "mapper_name":"TurboAgent"
-   },
-   {
-      "id":"508",
-      "name":"kz_tour_de_nuke_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055304",
-      "mapper_name":"bacUp",
-      "mapper_steamid64":"76561197992737822"
-   },
-   {
-      "id":"509",
-      "name":"kz_tradeblock_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=352763435",
-      "mapper_name":"Millet"
-   },
-   {
-      "id":"510",
-      "name":"kz_trashsurf",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419954977",
-      "mapper_name":"ticK!",
-      "mapper_steamid64":"76561198171545305"
-   },
-   {
-      "id":"783",
-      "name":"kz_trazodon_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2167786919",
-      "mapper_name":"Zeldox",
-      "mapper_steamid64":"76561197965379945"
-   },
-   {
-      "id":"511",
-      "name":"kz_tribute",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=771511732",
-      "mapper_name":"darksy",
-      "mapper_steamid64":"76561197985961109"
-   },
-   {
-      "id":"512",
-      "name":"kz_tron_global",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406055395"
-   },
-   {
-      "id":"677",
-      "name":"kz_twiivo",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1755261291",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198094382485"
-   },
-   {
-      "id":"493",
-      "name":"kz_twilight_od",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1885058481",
-      "mapper_name":"Overdose",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"787",
-      "name":"kz_twister",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2104121795",
-      "mapper_name":"Fksch",
-      "mapper_steamid64":"76561198142682783"
-   },
-   {
-      "id":"893",
-      "name":"kz_unity_collab",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=864605202",
-      "mapper_name":"G O A, Magical, ρ",
-      "mapper_steamid64":"76561197990887735, 76561197994466910, 76561198002830622"
-   },
-   {
-      "id":"513",
-      "name":"kz_unity_u01",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=519498299",
-      "mapper_name":"zPrince",
-      "mapper_steamid64":"76561198047032125"
-   },
-   {
-      "id":"690",
-      "name":"kz_unknownspace",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1738660683",
-      "mapper_name":"mjb",
-      "mapper_steamid64":"76561198093921774"
-   },
-   {
-      "id":"865",
-      "name":"kz_unmake",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2201592299",
-      "mapper_name":"Chichin",
-      "mapper_steamid64":"76561197991555455"
-   },
-   {
-      "id":"878",
-      "name":"kz_variety_fix",
-      "difficulty":"4",
-      "workshop_url":" https://steamcommunity.com/sharedfiles/filedetails/?id=2251584934",
-      "mapper_name":"Emzatin",
-      "mapper_steamid64":"76561198393292046"
-   },
-   {
-      "id":"514",
-      "name":"kz_vci_apprentice",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685276922",
-      "mapper_name":"VCi",
-      "mapper_steamid64":"76561198177716323"
-   },
-   {
-      "id":"515",
-      "name":"kz_verv3_gg",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=568150287",
-      "mapper_name":"Greg",
-      "mapper_steamid64":"76561198029772319"
-   },
-   {
-      "id":"630",
-      "name":"kz_village",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1613996676",
-      "mapper_name":"biql, GameChaos",
-      "mapper_steamid64":"76561198146445979, 76561198165203332"
-   },
-   {
-      "id":"516",
-      "name":"kz_violet_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=603787190",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"674",
-      "name":"kz_vittu_mika_persse",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1735347577",
-      "mapper_name":"victoria248",
-      "mapper_steamid64":"76561198026839022"
-   },
-   {
-      "id":"517",
-      "name":"kz_void",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=789833143",
-      "mapper_name":"finckelton",
-      "mapper_steamid64":"76561198039388458"
-   },
-   {
-      "id":"518",
-      "name":"kz_warehouse",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=288587982",
-      "mapper_name":"Witchhowl",
-      "mapper_steamid64":"76561198027343851"
-   },
-   {
-      "id":"657",
-      "name":"kz_waterhole",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1656359071",
-      "mapper_name":"lazovsky"
-   },
-   {
-      "id":"777",
-      "name":"kz_weebfactory_censored",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2110341385",
-      "mapper_name":"mark",
-      "mapper_steamid64":"76561198045869085"
-   },
-   {
-      "id":"611",
-      "name":"kz_wetbricks",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1341015034",
-      "mapper_name":"Random Eye",
-      "mapper_steamid64":"76561197987069371"
-   },
-   {
-      "id":"519",
-      "name":"kz_whatever_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=439146522",
-      "mapper_name":"GemaYue",
-      "mapper_steamid64":"76561198019909186"
-   },
-   {
-      "id":"678",
-      "name":"kz_why",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1773239409",
-      "mapper_name":"archon, Overdose",
-      "mapper_steamid64":"76561198034601835, 76561198142809343"
-   },
-   {
-      "id":"520",
-      "name":"kz_woodstock_v2",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=620160091",
-      "mapper_name":"pr3da",
-      "mapper_steamid64":"76561198021246024"
-   },
-   {
-      "id":"521",
-      "name":"kz_woodstonegrass_final",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=594369922",
-      "mapper_name":"MurrayAU",
-      "mapper_steamid64":"76561198019551123"
-   },
-   {
-      "id":"522",
-      "name":"kz_woodworld",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=306647639",
-      "mapper_name":"masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"523",
-      "name":"kz_xand",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=387908744",
-      "mapper_name":"a$ce"
-   },
-   {
-      "id":"615",
-      "name":"kz_xmas2008",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118382",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"616",
-      "name":"kz_xmas2009",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1627118842",
-      "mapper_name":"FoF, ρ",
-      "mapper_steamid64":"76561197991832101, 76561198002830622"
-   },
-   {
-      "id":"907",
-      "name":"kz_xmas2020",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2224396057",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"524",
-      "name":"kz_xtremeblock_v2",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156069128",
-      "mapper_name":"Chrizzy"
-   },
-   {
-      "id":"574",
-      "name":"kz_yoink",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1308906365",
-      "mapper_name":"bainz, GameChaos",
-      "mapper_steamid64":"76561198183817078, 76561198165203332"
-   },
-   {
-      "id":"822",
-      "name":"kz_zaloopazxc",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1918571009",
-      "mapper_name":"downeel",
-      "mapper_steamid64":"76561198160259346"
-   },
-   {
-      "id":"525",
-      "name":"kz_za_tileblock",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406080925",
-      "mapper_name":"Masque",
-      "mapper_steamid64":"76561197979436335"
-   },
-   {
-      "id":"526",
-      "name":"kz_zhop_freestyle",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=685863435",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"527",
-      "name":"kz_zhop_function3",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=606199162",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"528",
-      "name":"kz_zhop_son_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=580178806",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"529",
-      "name":"kz_ziggurath_final",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=684097443",
-      "mapper_name":"burny",
-      "mapper_steamid64":"76561197989457424"
-   },
-   {
-      "id":"729",
-      "name":"kz_zoomer_fix",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1996270299",
-      "mapper_name":"CoD",
-      "mapper_steamid64":"76561198846255522"
-   },
-   {
-      "id":"530",
-      "name":"kz_zxp_final4",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=632673660",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"645",
-      "name":"kz_zxp_interstellar_v2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1667954510",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"531",
-      "name":"kz_zxp_undia",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=639874816",
-      "mapper_name":"Zprince",
-      "mapper_steamid64":"76561198151858167"
-   },
-   {
-      "id":"612",
-      "name":"skz_bananaysoda_2",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1200744110",
-      "mapper_name":"Jony",
-      "mapper_steamid64":"76561198000829729"
-   },
-   {
-      "id":"589",
-      "name":"skz_makalaka",
-      "difficulty":"7",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1340859713",
-      "mapper_name":"Gamechaos",
-      "mapper_steamid64":"76561198165203332"
-   },
-   {
-      "id":"869",
-      "name":"skz_map",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2257677246",
-      "mapper_name":"Rush2sk8",
-      "mapper_steamid64":"76561198082904691"
-   },
-   {
-      "id":"640",
-      "name":"skz_odious_v2",
-      "difficulty":"6",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2001125206",
-      "mapper_name":"xq, Danvari",
-      "mapper_steamid64":"76561198094382485, 76561198038388449"
-   },
-   {
-      "id":"558",
-      "name":"skz_sati",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1226660943",
-      "mapper_name":"xq",
-      "mapper_steamid64":"76561198142809343"
-   },
-   {
-      "id":"891",
-      "name":"skz_sequence_shot",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2263251231",
-      "mapper_name":"lenny",
-      "mapper_steamid64":"76561198145963095"
-   },
-   {
-      "id":"633",
-      "name":"vnl_cat",
-      "difficulty":"4",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1594689613",
-      "mapper_name":"Schrødna",
-      "mapper_steamid64":"76561198067192262"
-   },
-   {
-      "id":"837",
-      "name":"vnl_invasion",
-      "difficulty":"5",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2027995295",
-      "mapper_name":"Birgit",
-      "mapper_steamid64":"76561198078014747"
-   },
-   {
-      "id":"841",
-      "name":"vnl_whiterun",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2209883717",
-      "mapper_name":"Spider1",
-      "mapper_steamid64":"76561198042146961"
-   },
-   {
-      "id":"778",
-      "name":"xc_alt_nephilim",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2072370967",
-      "mapper_name":"G O A",
-      "mapper_steamid64":"76561197990887735"
-   },
-   {
-      "id":"858",
-      "name":"xc_cliffjump_fix",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2215515724",
-      "mapper_name":"Tatska",
-      "mapper_steamid64":"76561198433558585"
-   },
-   {
-      "id":"596",
-      "name":"xc_dreamland2",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1287723058",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"559",
-      "name":"xc_dtt_nasty_go",
-      "difficulty":"1",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1257230741",
-      "mapper_name":"Dogers, ρ",
-      "mapper_steamid64":"null, 76561198002830622"
-   },
-   {
-      "id":"560",
-      "name":"xc_fox_shrine_japan_fr",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1279693156",
-      "mapper_name":"incAming"
-   },
-   {
-      "id":"532",
-      "name":"xc_karo4",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1193986481",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"533",
-      "name":"xc_lucid_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406056737",
-      "mapper_name":"G O A",
-      "mapper_steamid64":"76561197990887735"
-   },
-   {
-      "id":"534",
-      "name":"xc_minecraft2_global",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419053494",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"535",
-      "name":"xc_minecraft3_global",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=406057063",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"758",
-      "name":"xc_minecraft4",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=2025541839",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   },
-   {
-      "id":"536",
-      "name":"xc_nephilim",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
-      "mapper_name":"G O A"
-      "mapper_steamid64":"76561197990887735"
-   },
-   {
-      "id":"537",
-      "name":"xc_powerblock_rc1",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=156206701",
-      "mapper_name":"RZL",
-      "mapper_steamid64":"76561197985774978"
-   },
-   {
-      "id":"538",
-      "name":"xc_secret_valley_global_fix",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=451014834",
-      "mapper_name":"Sodan Tok"
-   },
-   {
-      "id":"539",
-      "name":"xc_skycastle",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1660023848",
-      "mapper_name":"Bendix, victoria248",
-      "mapper_steamid64":"null, 76561198026839022"
-   },
-   {
-      "id":"540",
-      "name":"xc_supermario_go_gfix",
-      "difficulty":"2",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=1939578036",
-      "mapper_name":"Disturbed, Iconic"
-   },
-   {
-      "id":"541",
-      "name":"xc_umbrella_global",
-      "difficulty":"3",
-      "workshop_url":"https://steamcommunity.com/sharedfiles/filedetails/?id=419054050",
-      "mapper_name":"ProAqua",
-      "mapper_steamid64":"76561198051496034"
-   }
+[{
+		"id": "200",
+		"name": "bkz_apricity_v3",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1986459033",
+		"mapper_name": "Badges",
+		"mapper_steamid64": "76561197983438223"
+	},
+	{
+		"id": "201",
+		"name": "bkz_blackrockshooter_vzp",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491358151",
+		"mapper_name": "Reborn",
+		"mapper_steamid64": "76561197992700411"
+	},
+	{
+		"id": "202",
+		"name": "bkz_bonus_z1",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509297499",
+		"mapper_name": "ZPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "269",
+		"name": "bkz_cakewalk",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1613453363",
+		"mapper_name": "zPrince, GameChaos",
+		"mapper_steamid64": "76561198047032125, 76561198165203332"
+	},
+	{
+		"id": "203",
+		"name": "bkz_cauz_final",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535665232",
+		"mapper_name": "Cau",
+		"mapper_steamid64": "76561198041208499"
+	},
+	{
+		"id": "204",
+		"name": "bkz_cauz_short",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535645053",
+		"mapper_name": "Cau",
+		"mapper_steamid64": "76561198041208499"
+	},
+	{
+		"id": "205",
+		"name": "bkz_caves_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=395902107",
+		"mapper_name": "pAtq",
+		"mapper_steamid64": "76561197997468889"
+	},
+	{
+		"id": "206",
+		"name": "bkz_cg_coldbhop",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=346170878",
+		"mapper_name": "DaMp"
+	},
+	{
+		"id": "207",
+		"name": "bkz_chillhop_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418435525",
+		"mapper_name": "FoF",
+		"mapper_steamid64": "76561197991832101"
+	},
+	{
+		"id": "597",
+		"name": "bkz_dontstop",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=449657758",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "208",
+		"name": "bkz_dydhop",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=784515943",
+		"mapper_name": "dydka",
+		"mapper_steamid64": "76561198010747369"
+	},
+	{
+		"id": "209",
+		"name": "bkz_evanstep",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=842652467",
+		"mapper_name": "Evanstep",
+		"mapper_steamid64": "76561198067339661"
+	},
+	{
+		"id": "551",
+		"name": "bkz_fapzor",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1304605829",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "542",
+		"name": "bkz_fear4",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1251914494",
+		"mapper_name": "Gull",
+		"mapper_steamid64": "76561198137589262"
+	},
+	{
+		"id": "210",
+		"name": "bkz_goldbhop_csgo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=245286254",
+		"mapper_name": "Sprite"
+	},
+	{
+		"id": "211",
+		"name": "bkz_goldbhop_v2go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=343824673",
+		"mapper_name": "Sprite"
+	},
+	{
+		"id": "212",
+		"name": "bkz_hellokitty_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688361403",
+		"mapper_name": "Kore"
+	},
+	{
+		"id": "213",
+		"name": "bkz_impulse",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418436480",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "661",
+		"name": "bkz_iota_v3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1734579951",
+		"mapper_name": "_Max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "767",
+		"name": "bkz_itz_h25l",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2076525905",
+		"mapper_name": "iTz",
+		"mapper_steamid64": "76561198104765796"
+	},
+	{
+		"id": "214",
+		"name": "bkz_levite_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667950111",
+		"mapper_name": "Levite",
+		"mapper_steamid64": "76561198031166668"
+	},
+	{
+		"id": "707",
+		"name": "bkz_lewlysex",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1904095585",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "215",
+		"name": "bkz_measure",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=366676751",
+		"mapper_name": "ExtremerZ",
+		"mapper_steamid64": "76561197965479288"
+	},
+	{
+		"id": "216",
+		"name": "bkz_measure2_b03",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498288711",
+		"mapper_name": "ExtremerZ",
+		"mapper_steamid64": "76561197965479288"
+	},
+	{
+		"id": "217",
+		"name": "bkz_nocturns_blue_gfix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939575460",
+		"mapper_name": "Levite",
+		"mapper_steamid64": "76561198031166668"
+	},
+	{
+		"id": "827",
+		"name": "bkz_pogo",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2136367398",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "218",
+		"name": "bkz_sahara",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1840329522",
+		"mapper_name": "noko, GameChaos",
+		"mapper_steamid64": "76561198013202660, 76561198165203332"
+	},
+	{
+		"id": "221",
+		"name": "bkz_underground_crypt_v3",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491359928",
+		"mapper_name": "Yaznee"
+	},
+	{
+		"id": "222",
+		"name": "bkz_uninspired_trash",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053096",
+		"mapper_name": "Felicienne"
+	},
+	{
+		"id": "223",
+		"name": "bkz_volcanohop",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=868101976",
+		"mapper_name": "Sprite"
+	},
+	{
+		"id": "820",
+		"name": "bkz_zephyr_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2173494916",
+		"mapper_name": "crixzzi",
+		"mapper_steamid64": "76561198046307458"
+	},
+	{
+		"id": "224",
+		"name": "kzpro_concrete_c02",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519499196",
+		"mapper_name": "ZPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "225",
+		"name": "kzpro_gull_pidr_reborn",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=642418824",
+		"mapper_name": "Gull",
+		"mapper_steamid64": "76561198137589262"
+	},
+	{
+		"id": "737",
+		"name": "kzpro_justrun_sp",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1982407165",
+		"mapper_name": "Saicho",
+		"mapper_steamid64": "76561197995141366"
+	},
+	{
+		"id": "543",
+		"name": "kz_11342",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1155205561",
+		"mapper_name": "persona, geryuganshoop, GameChaos",
+		"mapper_steamid64": "76561198143205331, 76561198068278361, 76561198165203332"
+	},
+	{
+		"id": "566",
+		"name": "kz_11735",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1333248573",
+		"mapper_name": "persona, geryuganshoop",
+		"mapper_steamid64": "76561198143205331, 76561198068278361"
+	},
+	{
+		"id": "226",
+		"name": "kz_21loop_final_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=431789622",
+		"mapper_name": "Gemayue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "885",
+		"name": "kz_2fast",
+		"difficulty": "3",
+		"workshop_url": "http://steamcommunity.com/sharedfiles/filedetails/?id=636149777",
+		"mapper_name": "Gull",
+		"mapper_steamid64": "76561198137589262"
+	},
+	{
+		"id": "227",
+		"name": "kz_2seasons_spring_final",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1242447001",
+		"mapper_name": "Gemayue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "581",
+		"name": "kz_2seasons_winter_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=793414645",
+		"mapper_name": "Gemayue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "870",
+		"name": "kz_420b",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=527350529",
+		"mapper_name": "Gull",
+		"mapper_steamid64": "76561198137589262"
+	},
+	{
+		"id": "228",
+		"name": "kz_4u_nature",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1102436466",
+		"mapper_name": "Ivansky",
+		"mapper_steamid64": "76561198057742312"
+	},
+	{
+		"id": "229",
+		"name": "kz_7in1",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667950835",
+		"mapper_name": "Woozie"
+	},
+	{
+		"id": "862",
+		"name": "kz_8b1_brickngrass",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228982453",
+		"mapper_name": "8ball1, Fenikzz",
+		"mapper_steamid64": "76561198322296161, 76561198152002232"
+	},
+	{
+		"id": "738",
+		"name": "kz_aaaa",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1934946150",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "631",
+		"name": "kz_abandoned",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1581715482",
+		"mapper_name": "Lillen",
+		"mapper_steamid64": "76561198077858937"
+	},
+	{
+		"id": "230",
+		"name": "kz_abstruse_od2",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=841710228",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "231",
+		"name": "kz_adventure_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2233744660",
+		"mapper_name": "Ownkruid, GnargarN",
+		"mapper_steamid64": "76561197985107159, 76561198009902429"
+	},
+	{
+		"id": "232",
+		"name": "kz_adv_cursedjourney",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=248583000",
+		"mapper_name": "Sinful",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "752",
+		"name": "kz_aether_fix",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1901960163",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "642",
+		"name": "kz_afterlife",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1625094133",
+		"mapper_name": "Jony, Broiler",
+		"mapper_steamid64": "76561198000829729, 76561198136166348"
+	},
+	{
+		"id": "233",
+		"name": "kz_after_agitation_easy_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=793417352",
+		"mapper_name": "Gemayue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "234",
+		"name": "kz_agility_v2_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=392863247",
+		"mapper_name": "Aaron"
+	},
+	{
+		"id": "235",
+		"name": "kz_ahful",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580309446",
+		"mapper_name": "Ahful",
+		"mapper_steamid64": "76561198177735294"
+	},
+	{
+		"id": "236",
+		"name": "kz_akrh_warehouse_v2_gfix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939575987",
+		"mapper_name": "AssKicR"
+	},
+	{
+		"id": "929",
+		"name": "kz_alfama",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2327257272",
+		"mapper_name": "Rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "662",
+		"name": "kz_alfie",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1360984181",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "237",
+		"name": "kz_alice_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=478203041",
+		"mapper_name": "VVoodchip",
+		"mapper_steamid64": "76561198061948302"
+	},
+	{
+		"id": "759",
+		"name": "kz_alien_city",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2017349111",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "957",
+		"name": "kz_allure",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2423290876",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "922",
+		"name": "kz_alouette_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2347901033",
+		"mapper_name": "Alouette, nopey",
+		"mapper_steamid64": "76561198044981479, 76561198401447544"
+	},
+	{
+		"id": "881",
+		"name": "kz_alpha",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030049320",
+		"mapper_name": "Dima",
+		"mapper_steamid64": "76561198198062889"
+	},
+	{
+		"id": "882",
+		"name": "kz_altum_od",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2241212276",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "768",
+		"name": "kz_alt_aztec",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2069005326",
+		"mapper_name": "SinFuL, fucker",
+		"mapper_steamid64": "76561197970838363, 76561198243661942"
+	},
+	{
+		"id": "785",
+		"name": "kz_alt_cargo",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1947965934",
+		"mapper_name": "eiRa, GameChaos",
+		"mapper_steamid64": "76561197977069783, 76561198165203332"
+	},
+	{
+		"id": "646",
+		"name": "kz_amber_od",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1651410465",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "238",
+		"name": "kz_ancient_v3",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=576216273",
+		"mapper_name": "Verifyy",
+		"mapper_steamid64": "76561197995535364"
+	},
+	{
+		"id": "832",
+		"name": "kz_andromeda",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2193435024",
+		"mapper_name": "TheLlamaKing",
+		"mapper_steamid64": "76561197993284480"
+	},
+	{
+		"id": "830",
+		"name": "kz_angina_final",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2182136940",
+		"mapper_name": "daolang, temmie",
+		"mapper_steamid64": "76561198814294487,  76561198137502865"
+	},
+	{
+		"id": "923",
+		"name": "kz_anotherclimbmap",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2271036340",
+		"mapper_name": "therapysession, nopey",
+		"mapper_steamid64": "76561198012265008, 76561198401447544"
+	},
+	{
+		"id": "826",
+		"name": "kz_antharas",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2137813215",
+		"mapper_name": "Fksch",
+		"mapper_steamid64": "76561198142682783"
+	},
+	{
+		"id": "803",
+		"name": "kz_antigeneric",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2136461557",
+		"mapper_name": "rush2sk8, EchoFrost",
+		"mapper_steamid64": "76561198082904691, 76561198121144282"
+	},
+	{
+		"id": "805",
+		"name": "kz_antimony",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2027793498",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "914",
+		"name": "kz_antiquity",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2275579584",
+		"mapper_name": "JustErroR^, GameChaos",
+		"mapper_steamid64": "76561198150858529, 76561198165203332"
+	},
+	{
+		"id": "801",
+		"name": "kz_anus",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2134749919",
+		"mapper_name": "suna",
+		"mapper_steamid64": "76561198845462726"
+	},
+	{
+		"id": "647",
+		"name": "kz_arbitrary_words",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1658130511",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "239",
+		"name": "kz_arcadium",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1178668090",
+		"mapper_name": "ivansky",
+		"mapper_steamid64": "76561198057742312"
+	},
+	{
+		"id": "629",
+		"name": "kz_arcturus",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1587362542",
+		"mapper_name": "Espoon",
+		"mapper_steamid64": "76561198055373574"
+	},
+	{
+		"id": "939",
+		"name": "kz_armored_core",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381741747",
+		"mapper_name": "J3wDice",
+		"mapper_steamid64": "76561198208729343"
+	},
+	{
+		"id": "240",
+		"name": "kz_arrebol",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=846831175",
+		"mapper_name": "Nthng",
+		"mapper_steamid64": "76561198124649132"
+	},
+	{
+		"id": "241",
+		"name": "kz_ascend_hv",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357729700",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "921",
+		"name": "kz_ashen",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2308615315",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "242",
+		"name": "kz_asphyxiate",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1694955173",
+		"mapper_name": "sqrt, victoria248",
+		"mapper_steamid64": "null, 76561198026839022"
+	},
+	{
+		"id": "243",
+		"name": "kz_asteroid_field_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=333421749",
+		"mapper_name": "SoUlFaThEr",
+		"mapper_steamid64": "76561197965266419"
+	},
+	{
+		"id": "567",
+		"name": "kz_atelectasis_sct",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1887458950",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "684",
+		"name": "kz_athena",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753252198",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198044055747"
+	},
+	{
+		"id": "847",
+		"name": "kz_atlantis_od3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996497943",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "244",
+		"name": "kz_autobadges",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509624370",
+		"mapper_name": "Badges",
+		"mapper_steamid64": "76561197983438223"
+	},
+	{
+		"id": "663",
+		"name": "kz_autumn_valley_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1747171037",
+		"mapper_name": "iBUYFL0WER Birgit",
+		"mapper_steamid64": "76561198078014747"
+	},
+	{
+		"id": "815",
+		"name": "kz_avalon",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2191500128",
+		"mapper_name": "Michael",
+		"mapper_steamid64": "76561198004229810"
+	},
+	{
+		"id": "245",
+		"name": "kz_avoria",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1199062647",
+		"mapper_name": "Smex",
+		"mapper_steamid64": "76561197961558198"
+	},
+	{
+		"id": "246",
+		"name": "kz_aztec",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156057488",
+		"mapper_name": "Sinful",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "635",
+		"name": "kz_azure",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1563199395",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "664",
+		"name": "kz_babycat_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1708424560",
+		"mapper_name": "Schrødna ",
+		"mapper_steamid64": "76561198067192262"
+	},
+	{
+		"id": "598",
+		"name": "kz_bacho",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1481626092",
+		"mapper_name": "Sodawater",
+		"mapper_steamid64": "76561198180483758"
+	},
+	{
+		"id": "871",
+		"name": "kz_backwards",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2236890476",
+		"mapper_name": "Emzatin",
+		"mapper_steamid64": "76561198393292046"
+	},
+	{
+		"id": "247",
+		"name": "kz_bananaysoda_v2",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2156821612",
+		"mapper_name": "Jony, fucker",
+		"mapper_steamid64": "76561198000829729, 76561198243661942"
+	},
+	{
+		"id": "739",
+		"name": "kz_banjo",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753959953",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "248",
+		"name": "kz_basicnoon",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=379026993",
+		"mapper_name": "RVE",
+		"mapper_steamid64": "76561198014015385"
+	},
+	{
+		"id": "249",
+		"name": "kz_basics_b02",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519499813",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "599",
+		"name": "kz_baxter",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1366794864",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "834",
+		"name": "kz_beanguy_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2197490213",
+		"mapper_name": "shnart, Nopey",
+		"mapper_steamid64": "76561198045654331, 76561198401447544"
+	},
+	{
+		"id": "250",
+		"name": "kz_beginnerblock_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156057667",
+		"mapper_name": "Ovi"
+	},
+	{
+		"id": "916",
+		"name": "kz_betapmaps",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2325269071",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "251",
+		"name": "kz_betterdunjun",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=523852277",
+		"mapper_name": "DannyE",
+		"mapper_steamid64": "76561198178232629"
+	},
+	{
+		"id": "894",
+		"name": "kz_bhop_badges2",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1899371128",
+		"mapper_name": "badges, ρ",
+		"mapper_steamid64": "76561197983438223, 76561198002830622"
+	},
+	{
+		"id": "665",
+		"name": "kz_bhop_badges3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1726813996",
+		"mapper_name": "badges, ρ",
+		"mapper_steamid64": "76561197983438223, 76561198002830622"
+	},
+	{
+		"id": "691",
+		"name": "kz_bhop_benchmark",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1776449850",
+		"mapper_name": "badges, ρ",
+		"mapper_steamid64": "76561197983438223, 76561198002830622"
+	},
+	{
+		"id": "634",
+		"name": "kz_bhop_dusk_go",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1617628780",
+		"mapper_name": "CraizZ, ρ",
+		"mapper_steamid64": "76561197993271570, 76561198002830622"
+	},
+	{
+		"id": "252",
+		"name": "kz_bhop_essence",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=788665755",
+		"mapper_name": "vay",
+		"mapper_steamid64": "76561198131632059"
+	},
+	{
+		"id": "898",
+		"name": "kz_bhop_koki_niwa",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2303161020",
+		"mapper_name": "noko",
+		"mapper_steamid64": "76561198013202660"
+	},
+	{
+		"id": "254",
+		"name": "kz_bhop_lj",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406077055",
+		"mapper_name": "badges",
+		"mapper_steamid64": "76561197983438223"
+	},
+	{
+		"id": "740",
+		"name": "kz_bhop_lucid",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1871085547",
+		"mapper_name": "keyuu, ρ",
+		"mapper_steamid64": "76561198003202977, 76561198002830622"
+	},
+	{
+		"id": "928",
+		"name": "kz_bhop_monsterjam",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2272849539",
+		"mapper_name": "Aoki, GameChaos",
+		"mapper_steamid64": "null, 76561198165203332"
+	},
+	{
+		"id": "582",
+		"name": "kz_bhop_mosaic_od2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=646510868",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "256",
+		"name": "kz_bhop_northface",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=642020842",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "544",
+		"name": "kz_bhop_nothing_go",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1204096299",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "794",
+		"name": "kz_bhop_sakura",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2124488428",
+		"mapper_name": ".yuka, TheIceTiger, murray",
+		"mapper_steamid64": "null, 76561198022081031, 76561198019551123"
+	},
+	{
+		"id": "257",
+		"name": "kz_bhop_skyworld_go",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=678315907",
+		"mapper_name": "ρ, Orbit",
+		"mapper_steamid64": "76561198002830622, 76561198057269402"
+	},
+	{
+		"id": "258",
+		"name": "kz_bhop_watertemple",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519457034",
+		"mapper_name": "Daza, SoUlFaThEr, zPrince",
+		"mapper_steamid64": "76561198007996091, 76561197965266419, 76561198047032125"
+	},
+	{
+		"id": "600",
+		"name": "kz_bhop_zenith",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=715243400",
+		"mapper_name": "Zorb, Cyclo",
+		"mapper_steamid64": "76561198144259350, 76561198024466262"
+	},
+	{
+		"id": "624",
+		"name": "kz_bible_black",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1617624549",
+		"mapper_name": "victoria248",
+		"mapper_steamid64": "76561198026839022"
+	},
+	{
+		"id": "920",
+		"name": "kz_bigcastle",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2303795750",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "769",
+		"name": "kz_binseebak",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2096008736",
+		"mapper_name": "L1nus",
+		"mapper_steamid64": "76561198835361052"
+	},
+	{
+		"id": "259",
+		"name": "kz_bionic",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=598309769",
+		"mapper_name": "Zorb",
+		"mapper_steamid64": "76561198144259350"
+	},
+	{
+		"id": "879",
+		"name": "kz_birrita_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240515420",
+		"mapper_name": "HermeticA",
+		"mapper_steamid64": "76561198082476569"
+	},
+	{
+		"id": "741",
+		"name": "kz_bir_dont_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2002208768",
+		"mapper_name": "Bird",
+		"mapper_steamid64": "76561198061987188"
+	},
+	{
+		"id": "641",
+		"name": "kz_blackness",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1582682050",
+		"mapper_name": "Jony",
+		"mapper_steamid64": "76561198000829729"
+	},
+	{
+		"id": "260",
+		"name": "kz_blatherskite_v1",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1201400569",
+		"mapper_name": "DannyE",
+		"mapper_steamid64": "76561198178232629"
+	},
+	{
+		"id": "261",
+		"name": "kz_blindcity_easy_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=673671001",
+		"mapper_name": "GemaYue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "262",
+		"name": "kz_blindcity_hard_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=450945426",
+		"mapper_name": "GemaYue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "618",
+		"name": "kz_blocks2006",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627115733",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "823",
+		"name": "kz_bloodline",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2169096895",
+		"mapper_name": "Makis",
+		"mapper_steamid64": "76561198201492663"
+	},
+	{
+		"id": "263",
+		"name": "kz_bluehop_mq",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1241443665",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "264",
+		"name": "kz_bluerace_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667952586",
+		"mapper_name": "tr4mp"
+	},
+	{
+		"id": "941",
+		"name": "kz_bluuu",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2416991755",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "601",
+		"name": "kz_bombu",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=742494584",
+		"mapper_name": "Bombu",
+		"mapper_steamid64": "76561198217095940"
+	},
+	{
+		"id": "849",
+		"name": "kz_boomblock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2206472013",
+		"mapper_name": "Szwagi",
+		"mapper_steamid64": "76561198857828380"
+	},
+	{
+		"id": "796",
+		"name": "kz_bounce",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2118830049",
+		"mapper_name": "Makis",
+		"mapper_steamid64": "76561198201492663"
+	},
+	{
+		"id": "265",
+		"name": "kz_breezeblocks",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=898027127",
+		"mapper_name": "BreeZ",
+		"mapper_steamid64": "76561198339346625"
+	},
+	{
+		"id": "266",
+		"name": "kz_brickblock_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=621434939",
+		"mapper_name": "masque, DanZay",
+		"mapper_steamid64": "76561197979436335, 76561197989817982"
+	},
+	{
+		"id": "926",
+		"name": "kz_bridge17_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2309106000",
+		"mapper_name": "pr3da, _max",
+		"mapper_steamid64": "76561198021246024, 76561198083065598"
+	},
+	{
+		"id": "267",
+		"name": "kz_brightblock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=653272914",
+		"mapper_name": "bboc",
+		"mapper_steamid64": "76561198000159327"
+	},
+	{
+		"id": "268",
+		"name": "kz_buildings_final",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406077441",
+		"mapper_name": "Vypur",
+		"mapper_steamid64": "76561198027553039"
+	},
+	{
+		"id": "895",
+		"name": "kz_burnished",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2120360302",
+		"mapper_name": "L1nus",
+		"mapper_steamid64": "76561198835361052"
+	},
+	{
+		"id": "911",
+		"name": "kz_byrem",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2327576026",
+		"mapper_name": "Rem, Antosha*",
+		"mapper_steamid64": "76561198072336874, 76561197974898839"
+	},
+	{
+		"id": "686",
+		"name": "kz_cabin_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240379784",
+		"mapper_name": "mjb",
+		"mapper_steamid64": "76561198093921774"
+	},
+	{
+		"id": "270",
+		"name": "kz_camembert",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=808050906",
+		"mapper_name": "BOWql",
+		"mapper_steamid64": "76561198190304705"
+	},
+	{
+		"id": "271",
+		"name": "kz_canyon",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=621630951",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "583",
+		"name": "kz_carbon",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1398723898",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "798",
+		"name": "kz_cargo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279210694",
+		"mapper_name": "eiRa, Alouette",
+		"mapper_steamid64": "null, 76561198044981479"
+	},
+	{
+		"id": "864",
+		"name": "kz_carp_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2241460284",
+		"mapper_name": "Andi, Nopey",
+		"mapper_steamid64": "76561198156668976, 76561198401447544"
+	},
+	{
+		"id": "272",
+		"name": "kz_cartooncastle_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1170804936",
+		"mapper_name": "s0liD, karatekafer",
+		"mapper_steamid64": "76561197980460370, null"
+	},
+	{
+		"id": "918",
+		"name": "kz_cascade_v4",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2356578123",
+		"mapper_name": "KingGambit",
+		"mapper_steamid64": "76561198023829871"
+	},
+	{
+		"id": "621",
+		"name": "kz_castlehops_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627116280",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "274",
+		"name": "kz_cataclysm",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370545981",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "275",
+		"name": "kz_catalyst_gfix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939576543",
+		"mapper_name": "umbrella"
+	},
+	{
+		"id": "276",
+		"name": "kz_catharsis_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=615332047",
+		"mapper_name": "kaldren.",
+		"mapper_steamid64": "76561197972347749"
+	},
+	{
+		"id": "277",
+		"name": "kz_caulis_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156058093",
+		"mapper_name": "Millet"
+	},
+	{
+		"id": "568",
+		"name": "kz_cdr_myst",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1391753126",
+		"mapper_name": "Dunk",
+		"mapper_steamid64": "76561197987174004"
+	},
+	{
+		"id": "627",
+		"name": "kz_cdr_rustenborg",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1401830672",
+		"mapper_name": "Dunk",
+		"mapper_steamid64": "76561197987174004"
+	},
+	{
+		"id": "569",
+		"name": "kz_cdr_slash_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1391789057",
+		"mapper_name": "Dunk",
+		"mapper_steamid64": "76561197987174004"
+	},
+	{
+		"id": "760",
+		"name": "kz_celestial",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2059174492",
+		"mapper_name": "mjb",
+		"mapper_steamid64": "76561198093921774"
+	},
+	{
+		"id": "278",
+		"name": "kz_cellblock_go2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156058850",
+		"mapper_name": "Millet"
+	},
+	{
+		"id": "814",
+		"name": "kz_cereal",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2176136694",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "279",
+		"name": "kz_cg_brick_rmk",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688171253",
+		"mapper_name": "InseN"
+	},
+	{
+		"id": "280",
+		"name": "kz_cg_lighthops_go",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352286796",
+		"mapper_name": "Mentalo, OldHead",
+		"mapper_steamid64": "null, 76561198009989298"
+	},
+	{
+		"id": "619",
+		"name": "kz_checkmate",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1535993215",
+		"mapper_name": "GameChaos",
+		"mapper_steamid64": "76561198165203332"
+	},
+	{
+		"id": "848",
+		"name": "kz_cheese",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2204525929",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "281",
+		"name": "kz_cheetos_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2234432420",
+		"mapper_name": "pe, Nopey",
+		"mapper_steamid64": "76561198212205417, 76561198401447544"
+	},
+	{
+		"id": "282",
+		"name": "kz_chessblock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=576215645",
+		"mapper_name": "AFlyingGuru"
+	},
+	{
+		"id": "283",
+		"name": "kz_chinablock",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279166189",
+		"mapper_name": "Sinful",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "840",
+		"name": "kz_chloroplast",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2194393186",
+		"mapper_name": "Plastyc",
+		"mapper_steamid64": "76561199024218227"
+	},
+	{
+		"id": "742",
+		"name": "kz_choka_fix",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1933623975",
+		"mapper_name": "JJ",
+		"mapper_steamid64": "76561198167125526"
+	},
+	{
+		"id": "897",
+		"name": "kz_chopchop",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187656713",
+		"mapper_name": "Sehk",
+		"mapper_steamid64": "76561198037724970"
+	},
+	{
+		"id": "284",
+		"name": "kz_christmas_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=669198796",
+		"mapper_name": "geryuganshoop",
+		"mapper_steamid64": "76561198068278361"
+	},
+	{
+		"id": "892",
+		"name": "kz_chrysoprase",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2237697111",
+		"mapper_name": "Michael",
+		"mapper_steamid64": "76561198004229810"
+	},
+	{
+		"id": "902",
+		"name": "kz_chunky_peanut_butter",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259665094",
+		"mapper_name": "rov",
+		"mapper_steamid64": "76561198132236283"
+	},
+	{
+		"id": "636",
+		"name": "kz_citadel",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1546644939",
+		"mapper_name": "aleiux",
+		"mapper_steamid64": "76561198090798444"
+	},
+	{
+		"id": "753",
+		"name": "kz_civilizations",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2034478444",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "285",
+		"name": "kz_cliffhanger_go_global",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=504851319",
+		"mapper_name": "Blind",
+		"mapper_steamid64": "76561198152317855"
+	},
+	{
+		"id": "825",
+		"name": "kz_coastline_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2171603497",
+		"mapper_name": "Steelo, Nopey",
+		"mapper_steamid64": "76561198279205361, 76561198401447544"
+	},
+	{
+		"id": "286",
+		"name": "kz_colorcode",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=528597060",
+		"mapper_name": "schm0ftie",
+		"mapper_steamid64": "76561197983561860"
+	},
+	{
+		"id": "287",
+		"name": "kz_colors_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=325027910",
+		"mapper_name": "Wally",
+		"mapper_steamid64": "76561197967777192"
+	},
+	{
+		"id": "288",
+		"name": "kz_combobreaker",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=908525075",
+		"mapper_name": "GameChaos",
+		"mapper_steamid64": "76561198165203332"
+	},
+	{
+		"id": "289",
+		"name": "kz_combohop_c02",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519498732",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "570",
+		"name": "kz_comboya",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1256315105",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "290",
+		"name": "kz_communityjump3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=659804813",
+		"mapper_name": "KZ Community"
+	},
+	{
+		"id": "291",
+		"name": "kz_complex",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=386875795",
+		"mapper_name": "teh_grave, DropInMilk",
+		"mapper_steamid64": "null, 76561198033385282"
+	},
+	{
+		"id": "292",
+		"name": "kz_comp_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053614",
+		"mapper_name": "ella",
+		"mapper_steamid64": "76561198069465729"
+	},
+	{
+		"id": "293",
+		"name": "kz_concept",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=903732207",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "294",
+		"name": "kz_concretejungle",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=506427184",
+		"mapper_name": "rev",
+		"mapper_steamid64": "76561197981308142"
+	},
+	{
+		"id": "650",
+		"name": "kz_conifer",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1699121278",
+		"mapper_name": "victoria248, GameChaos",
+		"mapper_steamid64": "76561198026839022, 76561198165203332"
+	},
+	{
+		"id": "295",
+		"name": "kz_conrun_mq",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=381648804",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "296",
+		"name": "kz_conrun_scrub",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=382262763",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "297",
+		"name": "kz_conspiracy",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=896555313",
+		"mapper_name": "Jakobe",
+		"mapper_steamid64": "76561198072850237"
+	},
+	{
+		"id": "298",
+		"name": "kz_construction",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=499184114",
+		"mapper_name": "finckelton",
+		"mapper_steamid64": "76561198039388458"
+	},
+	{
+		"id": "683",
+		"name": "kz_continuum",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1464119184",
+		"mapper_name": "Crash",
+		"mapper_steamid64": "76561197981212562"
+	},
+	{
+		"id": "552",
+		"name": "kz_coronado_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1381132298",
+		"mapper_name": "Cyclo",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "602",
+		"name": "kz_correguachin_reisido",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187796868",
+		"mapper_name": "Shendal",
+		"mapper_steamid64": "76561198225775664"
+	},
+	{
+		"id": "545",
+		"name": "kz_cousucks",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1241648205",
+		"mapper_name": "Krushed",
+		"mapper_steamid64": "76561197966948458"
+	},
+	{
+		"id": "943",
+		"name": "kz_cranking_the_hog",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381788599",
+		"mapper_name": "rov",
+		"mapper_steamid64": "76561198132236283"
+	},
+	{
+		"id": "828",
+		"name": "kz_crash_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2163399474",
+		"mapper_name": "Alouette, nopey",
+		"mapper_steamid64": "76561198044981479, 76561198401447544"
+	},
+	{
+		"id": "299",
+		"name": "kz_cratespeed",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=689965741",
+		"mapper_name": "ruben",
+		"mapper_steamid64": "76561198100183392"
+	},
+	{
+		"id": "300",
+		"name": "kz_crate_delight_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491405849",
+		"mapper_name": "SoUlFaThEr, zPrince",
+		"mapper_steamid64": "76561197965266419, 76561198047032125"
+	},
+	{
+		"id": "301",
+		"name": "kz_crypt_final",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=528128872",
+		"mapper_name": "Ryborg",
+		"mapper_steamid64": "76561198101913104"
+	},
+	{
+		"id": "302",
+		"name": "kz_crysis",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387238555",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "953",
+		"name": "kz_cuberunfast",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2420438992",
+		"mapper_name": "DannyE",
+		"mapper_steamid64": "76561198178232629"
+	},
+	{
+		"id": "303",
+		"name": "kz_custos",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1135144334",
+		"mapper_name": "xq, GameChaos",
+		"mapper_steamid64": "76561198094382485, 76561198165203332"
+	},
+	{
+		"id": "712",
+		"name": "kz_cyberspace_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996119569",
+		"mapper_name": "Charon",
+		"mapper_steamid64": "76561197979938663"
+	},
+	{
+		"id": "304",
+		"name": "kz_cyb_adrenaline_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1780391218",
+		"mapper_name": "cybur, masque",
+		"mapper_steamid64": "76561198062384407, 76561197979436335"
+	},
+	{
+		"id": "553",
+		"name": "kz_dakow",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1278987653",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "613",
+		"name": "kz_dale",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627116834",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "305",
+		"name": "kz_dam",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=647694230",
+		"mapper_name": "pr3da",
+		"mapper_steamid64": "76561198021246024"
+	},
+	{
+		"id": "306",
+		"name": "kz_daniel",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=416827844",
+		"mapper_name": "Khaleese",
+		"mapper_steamid64": "76561198123676539"
+	},
+	{
+		"id": "770",
+		"name": "kz_dank_stacks",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2075152351",
+		"mapper_name": "DankD",
+		"mapper_steamid64": "76561198039728576"
+	},
+	{
+		"id": "924",
+		"name": "kz_dark_fury",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2380315439",
+		"mapper_name": "sn00p, ρ",
+		"mapper_steamid64": "null, 76561198002830622"
+	},
+	{
+		"id": "307",
+		"name": "kz_date2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406439108",
+		"mapper_name": "s0liD, DropInMilk",
+		"mapper_steamid64": "76561197980460370, 76561198033385282"
+	},
+	{
+		"id": "308",
+		"name": "kz_default",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=382377001",
+		"mapper_name": "DropinMilk",
+		"mapper_steamid64": "76561198033385282"
+	},
+	{
+		"id": "622",
+		"name": "kz_dejavu",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1539800895",
+		"mapper_name": "Fnugz",
+		"mapper_steamid64": "76561198012891563"
+	},
+	{
+		"id": "811",
+		"name": "kz_delphinium",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2145751608",
+		"mapper_name": "Michael",
+		"mapper_steamid64": "76561198004229810"
+	},
+	{
+		"id": "309",
+		"name": "kz_depot",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=738046973",
+		"mapper_name": "f3vo",
+		"mapper_steamid64": "76561198040677227"
+	},
+	{
+		"id": "554",
+		"name": "kz_dethroned",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1295359223",
+		"mapper_name": "Cyclo",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "310",
+		"name": "kz_de_bhop",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509624659"
+	},
+	{
+		"id": "651",
+		"name": "kz_diajonal",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1626046474",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "311",
+		"name": "kz_dimensions_v1",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491411804",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "312",
+		"name": "kz_district_d01",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=421427380",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "908",
+		"name": "kz_divided",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2330433609",
+		"mapper_name": "J3wDice",
+		"mapper_steamid64": "76561198208729343"
+	},
+	{
+		"id": "925",
+		"name": "kz_dontjump",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2276652300",
+		"mapper_name": "Emzatin",
+		"mapper_steamid64": "76561198393292046"
+	},
+	{
+		"id": "313",
+		"name": "kz_doubletake",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491377297",
+		"mapper_name": "BeastF",
+		"mapper_steamid64": "76561197992587981"
+	},
+	{
+		"id": "314",
+		"name": "kz_doveen",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=391996291",
+		"mapper_name": "DoveeN",
+		"mapper_steamid64": "76561198033299991"
+	},
+	{
+		"id": "315",
+		"name": "kz_drops_od",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=631559848",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "937",
+		"name": "kz_drunkards",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2422272884",
+		"mapper_name": "Plastyc",
+		"mapper_steamid64": "76561199024218227"
+	},
+	{
+		"id": "316",
+		"name": "kz_dryness",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=611091154",
+		"mapper_name": "pr3da",
+		"mapper_steamid64": "76561198021246024"
+	},
+	{
+		"id": "317",
+		"name": "kz_duality_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1851066208",
+		"mapper_name": "VVoodchip, Zach47",
+		"mapper_steamid64": "76561198061948302, 76561197983014207"
+	},
+	{
+		"id": "318",
+		"name": "kz_dungeon",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515635506",
+		"mapper_name": "RyBorg",
+		"mapper_steamid64": "76561198101913104"
+	},
+	{
+		"id": "850",
+		"name": "kz_dust",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2187288428",
+		"mapper_name": "L1nus",
+		"mapper_steamid64": "76561198835361052"
+	},
+	{
+		"id": "319",
+		"name": "kz_dvn_cube_fixed",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498765580",
+		"mapper_name": "DoveeN",
+		"mapper_steamid64": "76561198033299991"
+	},
+	{
+		"id": "320",
+		"name": "kz_dvn_dull",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=483073135",
+		"mapper_name": "DoveeN",
+		"mapper_steamid64": "76561198033299991"
+	},
+	{
+		"id": "321",
+		"name": "kz_dvn_redcarpet",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=605822998",
+		"mapper_name": "DoveeN",
+		"mapper_steamid64": "76561198033299991"
+	},
+	{
+		"id": "713",
+		"name": "kz_dyd_ladderjumps",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1653452291",
+		"mapper_name": "dydka, GameChaos",
+		"mapper_steamid64": "76561198010747369, 76561198165203332"
+	},
+	{
+		"id": "322",
+		"name": "kz_dzy_beyond_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=454227310",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "323",
+		"name": "kz_dzy_reach_v2",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=673887976",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "324",
+		"name": "kz_ea_beneath_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=338561631",
+		"mapper_name": "rad0n, old head",
+		"mapper_steamid64": "null, 76561198009989298"
+	},
+	{
+		"id": "873",
+		"name": "kz_echo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259659098",
+		"mapper_name": "mjb",
+		"mapper_steamid64": "76561198093921774"
+	},
+	{
+		"id": "325",
+		"name": "kz_edifice",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=930321498",
+		"mapper_name": "Crixzzi",
+		"mapper_steamid64": "76561198046307458"
+	},
+	{
+		"id": "667",
+		"name": "kz_edp445",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1755737510",
+		"mapper_name": "victoria248",
+		"mapper_steamid64": "76561198026839022"
+	},
+	{
+		"id": "623",
+		"name": "kz_egyptianbox",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1576706552",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "326",
+		"name": "kz_emblem",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=489591399",
+		"mapper_name": "SinFul, Timmycakes",
+		"mapper_steamid64": "76561197970838363, 0"
+	},
+	{
+		"id": "327",
+		"name": "kz_emblem_bonus",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491412109",
+		"mapper_name": "SinFul, Timmycakes",
+		"mapper_steamid64": "76561197970838363, 0"
+	},
+	{
+		"id": "838",
+		"name": "kz_emptiness",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2203626680",
+		"mapper_name": "SneakY",
+		"mapper_steamid64": "76561198251129150"
+	},
+	{
+		"id": "328",
+		"name": "kz_ephemeral",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=692077375",
+		"mapper_name": "Tapzie",
+		"mapper_steamid64": "76561198122678894"
+	},
+	{
+		"id": "584",
+		"name": "kz_epiphany_v2",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1386147078",
+		"mapper_name": "Cyclo",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "329",
+		"name": "kz_epusbridge",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=303863578",
+		"mapper_name": "Deepus",
+		"mapper_steamid64": "76561197976153012"
+	},
+	{
+		"id": "930",
+		"name": "kz_erbajerb",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2304761102",
+		"mapper_name": "Birgit",
+		"mapper_steamid64": "76561198078014747"
+	},
+	{
+		"id": "330",
+		"name": "kz_erinome",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=568096729",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "331",
+		"name": "kz_eros_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=791910412",
+		"mapper_name": "finckelton, Kiwi",
+		"mapper_steamid64": "76561198039388458, 76561198077353609"
+	},
+	{
+		"id": "546",
+		"name": "kz_erratum_v2",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1170612689",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "936",
+		"name": "kz_eudora",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2312833379",
+		"mapper_name": "nowimime",
+		"mapper_steamid64": "76561198077383803"
+	},
+	{
+		"id": "585",
+		"name": "kz_eventide",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1382667484",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "799",
+		"name": "kz_everything",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2069925634",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "714",
+		"name": "kz_evilcorp",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1904796339",
+		"mapper_name": "Magier",
+		"mapper_steamid64": "76561198103471850"
+	},
+	{
+		"id": "332",
+		"name": "kz_excape",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406079956",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "333",
+		"name": "kz_excavate_b",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1440554662",
+		"mapper_name": "Badges",
+		"mapper_steamid64": "76561197983438223"
+	},
+	{
+		"id": "831",
+		"name": "kz_exemplum_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228224629",
+		"mapper_name": "Makis",
+		"mapper_steamid64": "76561198201492663"
+	},
+	{
+		"id": "334",
+		"name": "kz_exoteric",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=380505617",
+		"mapper_name": "Energy",
+		"mapper_steamid64": "76561198084022373"
+	},
+	{
+		"id": "335",
+		"name": "kz_experiment",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=398489890",
+		"mapper_name": "TheWhaleMan",
+		"mapper_steamid64": "76561198064508818"
+	},
+	{
+		"id": "336",
+		"name": "kz_exps_cursedjourney",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=525288912",
+		"mapper_name": "SinFul",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "337",
+		"name": "kz_ext_bblocks",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352448183",
+		"mapper_name": "Extermerz"
+	},
+	{
+		"id": "338",
+		"name": "kz_fabrik",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=221328962",
+		"mapper_name": "Snorres",
+		"mapper_steamid64": "76561197986556153"
+	},
+	{
+		"id": "339",
+		"name": "kz_failed_fastrun_rt",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688361058",
+		"mapper_name": "0n1yF4r7"
+	},
+	{
+		"id": "692",
+		"name": "kz_farm_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1750701302",
+		"mapper_name": "Chris, GameChaos",
+		"mapper_steamid64": "76561198044472964, 76561198165203332"
+	},
+	{
+		"id": "693",
+		"name": "kz_fas2map",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1699101066",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "340",
+		"name": "kz_fastcombomap",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=760052560",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "603",
+		"name": "kz_fastmap",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1448528308",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "341",
+		"name": "kz_fatigue_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=375133191",
+		"mapper_name": "Energy",
+		"mapper_steamid64": "76561198084022373"
+	},
+	{
+		"id": "342",
+		"name": "kz_fikablock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=674086581",
+		"mapper_name": "Jmonsted",
+		"mapper_steamid64": "76561198071182150"
+	},
+	{
+		"id": "343",
+		"name": "kz_final_ascension",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=551807622",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "694",
+		"name": "kz_flabbergast",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1770987028",
+		"mapper_name": "CyclO",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "344",
+		"name": "kz_floatingislands",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=738956347",
+		"mapper_name": "lillen",
+		"mapper_steamid64": "76561198077858937"
+	},
+	{
+		"id": "614",
+		"name": "kz_flying_rabbits",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627117444",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "888",
+		"name": "kz_fly_lovers",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2012561467",
+		"mapper_name": "Deppy, persona",
+		"mapper_steamid64": "null, 76561198143205331"
+	},
+	{
+		"id": "345",
+		"name": "kz_foggywarehouse_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387995227",
+		"mapper_name": "pb",
+		"mapper_steamid64": "76561197971221508"
+	},
+	{
+		"id": "253",
+		"name": "kz_forchi",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1860299808",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "346",
+		"name": "kz_forestrace_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=337879628",
+		"mapper_name": "h1m1, old head",
+		"mapper_steamid64": "null, 76561198009989298"
+	},
+	{
+		"id": "695",
+		"name": "kz_forgettable",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1399481815",
+		"mapper_name": "River",
+		"mapper_steamid64": "76561198054436805"
+	},
+	{
+		"id": "547",
+		"name": "kz_forgotten_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1213870327",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "347",
+		"name": "kz_free_ahful",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1167761258",
+		"mapper_name": "Persona",
+		"mapper_steamid64": "76561198143205331"
+	},
+	{
+		"id": "348",
+		"name": "kz_frozen_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066122",
+		"mapper_name": "SoUlFaThEr, SinFuL",
+		"mapper_steamid64": "76561197965266419, 76561197970838363"
+	},
+	{
+		"id": "884",
+		"name": "kz_fury",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224298709",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "652",
+		"name": "kz_fused",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1715598348",
+		"mapper_name": "mjb",
+		"mapper_steamid64": "76561198093921774"
+	},
+	{
+		"id": "349",
+		"name": "kz_futureblock",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=320897168",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "350",
+		"name": "kz_galaxy_go2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066234",
+		"mapper_name": "Woozie"
+	},
+	{
+		"id": "548",
+		"name": "kz_gallus",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=890259285",
+		"mapper_name": "Karo, Diesel",
+		"mapper_steamid64": "76561198059165508, 76561198099241969"
+	},
+	{
+		"id": "913",
+		"name": "kz_gary",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2280509631",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "474",
+		"name": "kz_gc_shark",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2080951339",
+		"mapper_name": "nykaN, GameChaos",
+		"mapper_steamid64": "76561198014491259, 76561198165203332"
+	},
+	{
+		"id": "643",
+		"name": "kz_gemischte_gefuehlslagen",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1280314788",
+		"mapper_name": "Heinzelboss",
+		"mapper_steamid64": "76561198155043164"
+	},
+	{
+		"id": "761",
+		"name": "kz_generic",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2047349909",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "351",
+		"name": "kz_genesis_go2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491406427",
+		"mapper_name": "FoF",
+		"mapper_steamid64": "76561197991832101"
+	},
+	{
+		"id": "352",
+		"name": "kz_gfy_blueberry",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=336069751",
+		"mapper_name": "Wally",
+		"mapper_steamid64": "76561197967777192"
+	},
+	{
+		"id": "353",
+		"name": "kz_gfy_c0mb0king",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352458126",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "354",
+		"name": "kz_gfy_devcastle",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399926903",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "355",
+		"name": "kz_gfy_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=438483912",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "356",
+		"name": "kz_gfy_fortroca_finallll",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352459359",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "357",
+		"name": "kz_gfy_limit",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=441312733",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "358",
+		"name": "kz_gfy_strawberry_",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352456857",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "359",
+		"name": "kz_gfy_tech",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=409983599",
+		"mapper_name": "winterNebs",
+		"mapper_steamid64": "76561198040798967"
+	},
+	{
+		"id": "360",
+		"name": "kz_ggurk",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1139544827",
+		"mapper_name": "AFlyingGuru, Flow",
+		"mapper_steamid64": "null, 76561197991750093"
+	},
+	{
+		"id": "617",
+		"name": "kz_ghat",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118013",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "361",
+		"name": "kz_giantbean",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066438",
+		"mapper_name": "KreedZ, SinFuL",
+		"mapper_steamid64": "76561197997103423, 76561197970838363"
+	},
+	{
+		"id": "362",
+		"name": "kz_gigablock_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=219883470",
+		"mapper_name": "KreedZ, Spherix",
+		"mapper_steamid64": "76561198016516359, null"
+	},
+	{
+		"id": "363",
+		"name": "kz_gitgud_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370366679",
+		"mapper_name": "VypuR",
+		"mapper_steamid64": "76561198027553039"
+	},
+	{
+		"id": "863",
+		"name": "kz_gkd_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2240110192",
+		"mapper_name": "Ap",
+		"mapper_steamid64": "76561198331631430"
+	},
+	{
+		"id": "364",
+		"name": "kz_glassesospa_v1",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=212501969",
+		"mapper_name": "Ospa",
+		"mapper_steamid64": "76561197992548863"
+	},
+	{
+		"id": "804",
+		"name": "kz_glide",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1816942862",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "668",
+		"name": "kz_gloom",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1747028736",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "653",
+		"name": "kz_gobbledygook",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1458270387",
+		"mapper_name": "J4BEE, Persona",
+		"mapper_steamid64": "76561198168982111, 76561198143205331"
+	},
+	{
+		"id": "365",
+		"name": "kz_goldenroad",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=227198727",
+		"mapper_name": "Ospa, Al2x",
+		"mapper_steamid64": "76561197992548863, 76561198037766292"
+	},
+	{
+		"id": "696",
+		"name": "kz_goldentabby",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1742520143",
+		"mapper_name": "ShadowBladeXtrm",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "366",
+		"name": "kz_gonbe",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=388981512",
+		"mapper_name": "skitty",
+		"mapper_steamid64": "76561198031452487"
+	},
+	{
+		"id": "367",
+		"name": "kz_goodluck_p",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=315108801",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "638",
+		"name": "kz_goquicklol_v2",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1674495693",
+		"mapper_name": "Mark",
+		"mapper_steamid64": "76561198045869085"
+	},
+	{
+		"id": "368",
+		"name": "kz_grass_hard",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491359087",
+		"mapper_name": "Extremerz",
+		"mapper_steamid64": "76561197965479288"
+	},
+	{
+		"id": "369",
+		"name": "kz_green",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=425209295",
+		"mapper_name": "Piu",
+		"mapper_steamid64": "76561198014009703"
+	},
+	{
+		"id": "370",
+		"name": "kz_gy_agitation",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=444123619",
+		"mapper_name": "Gemayue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "371",
+		"name": "kz_haki_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156066638",
+		"mapper_name": "a$ce"
+	},
+	{
+		"id": "499",
+		"name": "kz_halicarnassus_fs",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2080802644",
+		"mapper_name": "Zengal, SinFuL",
+		"mapper_steamid64": "null, 76561197970838363"
+	},
+	{
+		"id": "792",
+		"name": "kz_hammer",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2133476426",
+		"mapper_name": "Makis",
+		"mapper_steamid64": "76561198201492663"
+	},
+	{
+		"id": "717",
+		"name": "kz_haste",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1877331884",
+		"mapper_name": "Dillon",
+		"mapper_steamid64": "76561198120868833"
+	},
+	{
+		"id": "372",
+		"name": "kz_hate",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=875611390",
+		"mapper_name": "Yams",
+		"mapper_steamid64": "76561198348576275"
+	},
+	{
+		"id": "373",
+		"name": "kz_heatvents_mq",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=459351652",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "697",
+		"name": "kz_heaven_od",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1705891534",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "843",
+		"name": "kz_hek",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2175513019",
+		"mapper_name": "Pigeon",
+		"mapper_steamid64": "76561198164405482"
+	},
+	{
+		"id": "374",
+		"name": "kz_hellinashop",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515649978",
+		"mapper_name": "8Ball1, SinFuL",
+		"mapper_steamid64": "null, 76561197970838363"
+	},
+	{
+		"id": "839",
+		"name": "kz_hemochromatosis",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2044616297",
+		"mapper_name": "rov",
+		"mapper_steamid64": "76561198132236283"
+	},
+	{
+		"id": "375",
+		"name": "kz_highland",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=656212893",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "719",
+		"name": "kz_high_socks",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1984921434",
+		"mapper_name": "GameChaos, Samuel",
+		"mapper_steamid64": "76561198165203332, 76561198191875674"
+	},
+	{
+		"id": "586",
+		"name": "kz_hikari_od",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=884785011",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "377",
+		"name": "kz_hillside",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=414544226",
+		"mapper_name": "s0liD",
+		"mapper_steamid64": "76561197980460370"
+	},
+	{
+		"id": "376",
+		"name": "kz_hitech",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2002217295",
+		"mapper_name": "nykaN",
+		"mapper_steamid64": "76561198014491259"
+	},
+	{
+		"id": "681",
+		"name": "kz_holyspace",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1771753813",
+		"mapper_name": "SodaWater",
+		"mapper_steamid64": "76561198180483758"
+	},
+	{
+		"id": "817",
+		"name": "kz_how2slide_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2166904834",
+		"mapper_name": "Dima",
+		"mapper_steamid64": "76561198198062889"
+	},
+	{
+		"id": "720",
+		"name": "kz_huber",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1702853550",
+		"mapper_name": "Durox",
+		"mapper_steamid64": "76561198072521803"
+	},
+	{
+		"id": "378",
+		"name": "kz_ickkck",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=822776276",
+		"mapper_name": "Rosquilla Guy",
+		"mapper_steamid64": "76561198102575797"
+	},
+	{
+		"id": "379",
+		"name": "kz_illusion_gfix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939577141",
+		"mapper_name": "schm0ftie",
+		"mapper_steamid64": "76561197983561860"
+	},
+	{
+		"id": "380",
+		"name": "kz_iluvprok_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406053852",
+		"mapper_name": "Nitekillr",
+		"mapper_steamid64": "76561197987002717"
+	},
+	{
+		"id": "381",
+		"name": "kz_imaginary_final",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=843659203",
+		"mapper_name": "JONY",
+		"mapper_steamid64": "76561198000829729"
+	},
+	{
+		"id": "382",
+		"name": "kz_innit",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1209786787",
+		"mapper_name": "bainz, GameChaos, Danvari",
+		"mapper_steamid64": "76561198183817078, 76561198165203332, 76561198038388449"
+	},
+	{
+		"id": "383",
+		"name": "kz_insomnia_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=594168198",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "384",
+		"name": "kz_inspired",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=370117755",
+		"mapper_name": "Kaldren",
+		"mapper_steamid64": "76561197972347749"
+	},
+	{
+		"id": "860",
+		"name": "kz_intercourse!",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207574101",
+		"mapper_name": "stz",
+		"mapper_steamid64": "76561198261992780"
+	},
+	{
+		"id": "385",
+		"name": "kz_internatus",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=551443219",
+		"mapper_name": "Deepus",
+		"mapper_steamid64": "76561197976153012"
+	},
+	{
+		"id": "386",
+		"name": "kz_island",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357579568",
+		"mapper_name": "JumBoO",
+		"mapper_steamid64": "7656119813262611"
+	},
+	{
+		"id": "950",
+		"name": "kz_itz_transcendent",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2373968399",
+		"mapper_name": "iTz",
+		"mapper_steamid64": "76561198104765796"
+	},
+	{
+		"id": "387",
+		"name": "kz_j2s_cupblock_go_fix2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156908740",
+		"mapper_name": "s0lid, Spherix",
+		"mapper_steamid64": "76561197980460370, null"
+	},
+	{
+		"id": "388",
+		"name": "kz_j2s_tetris_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279998195",
+		"mapper_name": "s0lid, fl0w",
+		"mapper_steamid64": "76561197980460370, 76561197991750093"
+	},
+	{
+		"id": "389",
+		"name": "kz_j2s_westbl0ck",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=625392149",
+		"mapper_name": "s0lid, fl0w, DanZay",
+		"mapper_steamid64": "76561197980460370, 76561197991750093, 76561197989817982"
+	},
+	{
+		"id": "390",
+		"name": "kz_janpu_final_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=357085110",
+		"mapper_name": "Verifyy",
+		"mapper_steamid64": "76561197995535364"
+	},
+	{
+		"id": "391",
+		"name": "kz_jg_ditch",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=367347758",
+		"mapper_name": "ticK!",
+		"mapper_steamid64": "76561198171545305"
+	},
+	{
+		"id": "754",
+		"name": "kz_johndoe",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2015357272",
+		"mapper_name": "Bolo",
+		"mapper_steamid64": "76561198297512910"
+	},
+	{
+		"id": "392",
+		"name": "kz_jump_n_run",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=629040765",
+		"mapper_name": "Smex",
+		"mapper_steamid64": "76561197961558198"
+	},
+	{
+		"id": "889",
+		"name": "kz_kat_colorblind",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2277557067",
+		"mapper_name": "katz, rush2sk8",
+		"mapper_steamid64": "76561198067576863, 76561198082904691"
+	},
+	{
+		"id": "952",
+		"name": "kz_kiwiexultation",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2415258457",
+		"mapper_name": "Kiwi",
+		"mapper_steamid64": "76561198077353609"
+	},
+	{
+		"id": "844",
+		"name": "kz_kiwitech",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2229046768",
+		"mapper_name": "Kiwi",
+		"mapper_steamid64": "76561198077353609"
+	},
+	{
+		"id": "951",
+		"name": "kz_kiwiterror",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2413286682",
+		"mapper_name": "Kiwi",
+		"mapper_steamid64": "76561198077353609"
+	},
+	{
+		"id": "932",
+		"name": "kz_kiwi_cod",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2256093157",
+		"mapper_name": "Kiwi, CoD",
+		"mapper_steamid64": "76561198077353609, 76561198846255522"
+	},
+	{
+		"id": "800",
+		"name": "kz_kohze_sucks",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2130097882",
+		"mapper_name": "Krushed",
+		"mapper_steamid64": "76561197966948458"
+	},
+	{
+		"id": "394",
+		"name": "kz_kzinga_fixed",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=455178914",
+		"mapper_name": "finckelton",
+		"mapper_steamid64": "76561198039388458"
+	},
+	{
+		"id": "762",
+		"name": "kz_kzra_bars",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1901874741",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "763",
+		"name": "kz_kzra_cliffy",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1912922798",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "771",
+		"name": "kz_kzra_hohum",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1877338856",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "682",
+		"name": "kz_kzra_morath",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1761949860",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "793",
+		"name": "kz_kzra_oddland",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2105252723",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "669",
+		"name": "kz_kzra_shortclimb_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1753701773",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "699",
+		"name": "kz_kzra_skaxis",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1846345249",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "700",
+		"name": "kz_kzra_slidely",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1816052873",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "887",
+		"name": "kz_kzra_slidepuf",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1824161798",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "851",
+		"name": "kz_kzra_stoneishbhop",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207370784",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "701",
+		"name": "kz_kzra_voovblock",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1795477339",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "685",
+		"name": "kz_kzra_whitesquare",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1793270481",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "772",
+		"name": "kz_kzro_brickstgrass_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2235348857",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "866",
+		"name": "kz_kzro_bronea",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2237646194",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "808",
+		"name": "kz_kzro_gohome",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2117028264",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "867",
+		"name": "kz_kzro_hardvalley",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215405289",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "786",
+		"name": "kz_kzro_mountainbhop",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2118958853",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "906",
+		"name": "kz_kzro_mountainsein",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2207874525",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "896",
+		"name": "kz_kzro_mountainsnow",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2230533130",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "883",
+		"name": "kz_kzro_slidesmear",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2239093087",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "845",
+		"name": "kz_kzro_sunmountainset",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2222540470",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "395",
+		"name": "kz_kzse_aztectemple",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=302894093",
+		"mapper_name": "Sinful",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "791",
+		"name": "kz_ladderall",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2124189658",
+		"mapper_name": "Cou",
+		"mapper_steamid64": "76561198007928944"
+	},
+	{
+		"id": "833",
+		"name": "kz_ladderdespair",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2191784508",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "755",
+		"name": "kz_ladderhell_fix",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2034623068",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "396",
+		"name": "kz_lavablock_global",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406054554",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "900",
+		"name": "kz_layercake",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2255773578",
+		"mapper_name": "Downie2K",
+		"mapper_steamid64": "76561197981037626"
+	},
+	{
+		"id": "788",
+		"name": "kz_lazy",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2105506029",
+		"mapper_name": "Michael, Haakz",
+		"mapper_steamid64": "76561198004229810, 76561197990350366"
+	},
+	{
+		"id": "397",
+		"name": "kz_lego",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=351298054",
+		"mapper_name": "DutchSnowman",
+		"mapper_steamid64": "76561198027507070"
+	},
+	{
+		"id": "398",
+		"name": "kz_lego_two_redux_v3",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=515550870",
+		"mapper_name": "DutchSnowman",
+		"mapper_steamid64": "76561198027507070"
+	},
+	{
+		"id": "399",
+		"name": "kz_levels",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=635973918",
+		"mapper_name": "Jurkelis",
+		"mapper_steamid64": "76561198071655291"
+	},
+	{
+		"id": "400",
+		"name": "kz_life_final",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=683576131",
+		"mapper_name": "Chaosangel",
+		"mapper_steamid64": "76561198078333036"
+	},
+	{
+		"id": "721",
+		"name": "kz_lionheart",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1805200433",
+		"mapper_name": "iBUYFL0WER Birgit, nutsdoodle",
+		"mapper_steamid64": "76561198078014747, 76561198150143219"
+	},
+	{
+		"id": "819",
+		"name": "kz_list_gnida_v2",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=630032870",
+		"mapper_name": "DeadRote",
+		"mapper_steamid64": "76561198034507626"
+	},
+	{
+		"id": "401",
+		"name": "kz_littlerock_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156067138",
+		"mapper_name": "Surion"
+	},
+	{
+		"id": "917",
+		"name": "kz_loathe",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1961922598",
+		"mapper_name": "JJ",
+		"mapper_steamid64": "76561198167125526"
+	},
+	{
+		"id": "842",
+		"name": "kz_longjumps_easy",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=409720195",
+		"mapper_name": "ExtremerZ",
+		"mapper_steamid64": "76561197965479288"
+	},
+	{
+		"id": "604",
+		"name": "kz_longjumps_space",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=637925784",
+		"mapper_name": "JONY, CyclO",
+		"mapper_steamid64": "76561198000829729, 76561198024466262"
+	},
+	{
+		"id": "876",
+		"name": "kz_lookout",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2245294640",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "644",
+		"name": "kz_lost_marketplace_gfix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939577604",
+		"mapper_name": "JONY, Rosquilla Guy",
+		"mapper_steamid64": "76561198000829729, 76561198102575797"
+	},
+	{
+		"id": "933",
+		"name": "kz_lovely",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2227118054",
+		"mapper_name": "makis",
+		"mapper_steamid64": "76561198201492663"
+	},
+	{
+		"id": "403",
+		"name": "kz_lume",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=717341154",
+		"mapper_name": "VVoodchip",
+		"mapper_steamid64": "76561198061948302"
+	},
+	{
+		"id": "404",
+		"name": "kz_luonto",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1102578759",
+		"mapper_name": "sBlisss, GameChaos",
+		"mapper_steamid64": "null, 76561198165203332"
+	},
+	{
+		"id": "938",
+		"name": "kz_luv_less",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2350173887",
+		"mapper_name": "J3wDice",
+		"mapper_steamid64": "76561198208729343"
+	},
+	{
+		"id": "405",
+		"name": "kz_mac",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=336084898",
+		"mapper_name": "mac",
+		"mapper_steamid64": "76561198056335207"
+	},
+	{
+		"id": "743",
+		"name": "kz_machinery",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1921655838",
+		"mapper_name": "iBUYFL0WER Birgit",
+		"mapper_steamid64": "76561198078014747"
+	},
+	{
+		"id": "406",
+		"name": "kz_magus",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=401088222",
+		"mapper_name": "Doveen",
+		"mapper_steamid64": "76561198033299991"
+	},
+	{
+		"id": "756",
+		"name": "kz_malignom_short",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1962044626",
+		"mapper_name": "jens",
+		"mapper_steamid64": "76561198110357840"
+	},
+	{
+		"id": "942",
+		"name": "kz_mandelbrot",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259048305",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "407",
+		"name": "kz_man_everest_go_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1098716930",
+		"mapper_name": "Kreedz, Spherix, GnagarN",
+		"mapper_steamid64": "76561197997103423, null, 76561198009902429"
+	},
+	{
+		"id": "408",
+		"name": "kz_marblewalls_fixed",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=391298485",
+		"mapper_name": "Aaron"
+	},
+	{
+		"id": "587",
+		"name": "kz_matilda_np",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1442293882",
+		"mapper_name": "Matilda",
+		"mapper_steamid64": "76561197999312081"
+	},
+	{
+		"id": "670",
+		"name": "kz_meander",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1657680583",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "410",
+		"name": "kz_megabhop_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667953480",
+		"mapper_name": "N1ghtFoX, Chuli"
+	},
+	{
+		"id": "411",
+		"name": "kz_megalodon",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1184142056",
+		"mapper_name": "nykaN",
+		"mapper_steamid64": "76561198014491259"
+	},
+	{
+		"id": "868",
+		"name": "kz_memento",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2226685570",
+		"mapper_name": "Downie2K",
+		"mapper_steamid64": "76561197981037626"
+	},
+	{
+		"id": "654",
+		"name": "kz_mescaline_f",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1704411752",
+		"mapper_name": "mark",
+		"mapper_steamid64": "76561198045869085"
+	},
+	{
+		"id": "412",
+		"name": "kz_metalrun_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406054781",
+		"mapper_name": "Witchhowl",
+		"mapper_steamid64": "76561198027343851"
+	},
+	{
+		"id": "903",
+		"name": "kz_micropenis",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2274722735",
+		"mapper_name": "Cou ",
+		"mapper_steamid64": "76561198007928944"
+	},
+	{
+		"id": "905",
+		"name": "kz_microwave",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2259353310",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "824",
+		"name": "kz_mieszaneuczucia",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2168009794",
+		"mapper_name": "nutsdoodle",
+		"mapper_steamid64": "76561198150143219"
+	},
+	{
+		"id": "413",
+		"name": "kz_mike_v4",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352438024",
+		"mapper_name": "MikeChas",
+		"mapper_steamid64": "76561198033854242"
+	},
+	{
+		"id": "773",
+		"name": "kz_milehigh",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2081487108",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "414",
+		"name": "kz_minimalism",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=784686492",
+		"mapper_name": "badges, ρ",
+		"mapper_steamid64": "76561197983438223, 76561198002830622"
+	},
+	{
+		"id": "605",
+		"name": "kz_minimal_combo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=688173479",
+		"mapper_name": "UNKNOWN:(",
+		"mapper_steamid64": "76561198140867695"
+	},
+	{
+		"id": "415",
+		"name": "kz_minimountain_f",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1819270715",
+		"mapper_name": "finckelton",
+		"mapper_steamid64": "76561198039388458"
+	},
+	{
+		"id": "588",
+		"name": "kz_modernvomit",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1387010348",
+		"mapper_name": "evanstep",
+		"mapper_steamid64": "76561198067339661"
+	},
+	{
+		"id": "416",
+		"name": "kz_module",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=531121171",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "417",
+		"name": "kz_moonlight",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=653958895",
+		"mapper_name": "jurkelis",
+		"mapper_steamid64": "76561198071655291"
+	},
+	{
+		"id": "625",
+		"name": "kz_moorerutan",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1538928192",
+		"mapper_name": "Rumme",
+		"mapper_steamid64": "76561198112936613"
+	},
+	{
+		"id": "418",
+		"name": "kz_morebricks_msq",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=624692501",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "571",
+		"name": "kz_morestairs_msq",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1370543054",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "807",
+		"name": "kz_motivated",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=504145143",
+		"mapper_name": "Drinka",
+		"mapper_steamid64": "76561198100929785"
+	},
+	{
+		"id": "419",
+		"name": "kz_msp_comatose",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418089472",
+		"mapper_name": "Pebi, masque, skitty",
+		"mapper_steamid64": "76561198077530872, 76561197979436335, 76561198031452487"
+	},
+	{
+		"id": "875",
+		"name": "kz_mushrruption_v8",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2280643029",
+		"mapper_name": "Sehk",
+		"mapper_steamid64": "76561198037724970"
+	},
+	{
+		"id": "744",
+		"name": "kz_mz",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1988044539",
+		"mapper_name": "Zach47, nykaN",
+		"mapper_steamid64": "76561197983014207, 76561198014491259"
+	},
+	{
+		"id": "784",
+		"name": "kz_nassau",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2096632231",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "420",
+		"name": "kz_natureblock_scte",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2111399696",
+		"mapper_name": "Chichin, Pr3da",
+		"mapper_steamid64": "76561197991555455, 76561198021246024"
+	},
+	{
+		"id": "421",
+		"name": "kz_nature_csgo",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080089",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "904",
+		"name": "kz_nb_final",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2246885072",
+		"mapper_name": "Da0lang",
+		"mapper_steamid64": "76561198814294487"
+	},
+	{
+		"id": "947",
+		"name": "kz_neoncity_z",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2260637520",
+		"mapper_name": "_Z",
+		"mapper_steamid64": "76561198365448333"
+	},
+	{
+		"id": "422",
+		"name": "kz_neon_portal",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=427001332",
+		"mapper_name": "TherapySession",
+		"mapper_steamid64": "76561198012265008"
+	},
+	{
+		"id": "802",
+		"name": "kz_nieh",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2128027875",
+		"mapper_name": "S1lic",
+		"mapper_steamid64": "76561198874435443"
+	},
+	{
+		"id": "810",
+		"name": "kz_nightcastle",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2143021601",
+		"mapper_name": "Petter",
+		"mapper_steamid64": "76561198416084167"
+	},
+	{
+		"id": "423",
+		"name": "kz_nightfall",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2073457452",
+		"mapper_name": "Pebi, Danvari",
+		"mapper_steamid64": "76561198077530872, 76561198038388449"
+	},
+	{
+		"id": "424",
+		"name": "kz_nightmare_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=386548794",
+		"mapper_name": "m-tet"
+	},
+	{
+		"id": "698",
+		"name": "kz_nix_od",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1773124335",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "809",
+		"name": "kz_noobfort",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2128202621",
+		"mapper_name": "Lux",
+		"mapper_steamid64": "76561198055771460"
+	},
+	{
+		"id": "940",
+		"name": "kz_northkorean_censorship",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2382813554",
+		"mapper_name": "rov",
+		"mapper_steamid64": "76561198132236283"
+	},
+	{
+		"id": "425",
+		"name": "kz_nyc_v1",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
+		"mapper_name": "Vypur",
+		"mapper_steamid64": "76561198027553039"
+	},
+	{
+		"id": "606",
+		"name": "kz_nymph",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=498308628",
+		"mapper_name": "Cyclo",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "426",
+		"name": "kz_oasis",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=650371940",
+		"mapper_name": "Pebi",
+		"mapper_steamid64": "76561198077530872"
+	},
+	{
+		"id": "427",
+		"name": "kz_obsidian",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418449564",
+		"mapper_name": "SinFuL",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "723",
+		"name": "kz_okaychamp",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1881193335",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "428",
+		"name": "kz_oldstuff",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=491404667",
+		"mapper_name": "DannyE",
+		"mapper_steamid64": "76561198178232629"
+	},
+	{
+		"id": "572",
+		"name": "kz_oloramasa",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1282978596",
+		"mapper_name": "Alves",
+		"mapper_steamid64": "76561198063573203"
+	},
+	{
+		"id": "429",
+		"name": "kz_olympus",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=171110248",
+		"mapper_name": "KingGambit",
+		"mapper_steamid64": "76561198023829871"
+	},
+	{
+		"id": "430",
+		"name": "kz_ominous2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=782868988",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "655",
+		"name": "kz_openspace",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1685172182",
+		"mapper_name": "Lazovsky",
+		"mapper_steamid64": "76561198003859123"
+	},
+	{
+		"id": "431",
+		"name": "kz_orangejuice_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=813837226",
+		"mapper_name": "masque, DanZay",
+		"mapper_steamid64": "76561197979436335, 76561197989817982"
+	},
+	{
+		"id": "432",
+		"name": "kz_orbolution_v2",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=644224500",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "795",
+		"name": "kz_otakuroom",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2106385628",
+		"mapper_name": "GemaYue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "433",
+		"name": "kz_overgrowth",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1092513702",
+		"mapper_name": "stz",
+		"mapper_steamid64": "76561198261992780"
+	},
+	{
+		"id": "626",
+		"name": "kz_overjoyed",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1465826915",
+		"mapper_name": "Gamzky",
+		"mapper_steamid64": "76561198262673963"
+	},
+	{
+		"id": "829",
+		"name": "kz_owtetad",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2190664967",
+		"mapper_name": "Krushed",
+		"mapper_steamid64": "76561197966948458"
+	},
+	{
+		"id": "724",
+		"name": "kz_p1",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1684028086",
+		"mapper_name": "JONY",
+		"mapper_steamid64": "76561198000829729"
+	},
+	{
+		"id": "676",
+		"name": "kz_paintball_tv_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1717536029",
+		"mapper_name": "pb, victoria248",
+		"mapper_steamid64": "76561197971221508, 76561198026839022"
+	},
+	{
+		"id": "774",
+		"name": "kz_pamxul_wip",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2085124881",
+		"mapper_name": "Lux",
+		"mapper_steamid64": "76561198055771460"
+	},
+	{
+		"id": "434",
+		"name": "kz_pantheism_p02",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519500089",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "435",
+		"name": "kz_paradise",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=636580309",
+		"mapper_name": "pr3da",
+		"mapper_steamid64": "76561198021246024"
+	},
+	{
+		"id": "436",
+		"name": "kz_peak_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419054557",
+		"mapper_name": "PHQ",
+		"mapper_steamid64": "76561197981825703"
+	},
+	{
+		"id": "934",
+		"name": "kz_pendulum",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1937590263",
+		"mapper_name": "JJ",
+		"mapper_steamid64": "76561198167125526"
+	},
+	{
+		"id": "931",
+		"name": "kz_perfunctory",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2253427267",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "437",
+		"name": "kz_phamous",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=404322417",
+		"mapper_name": "Phinx",
+		"mapper_steamid64": "76561198023207107"
+	},
+	{
+		"id": "438",
+		"name": "kz_pharaoh_csgo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=377402121",
+		"mapper_name": "Daniel_Lyness"
+	},
+	{
+		"id": "859",
+		"name": "kz_pharos_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2274441302",
+		"mapper_name": "Crixxzi",
+		"mapper_steamid64": "76561198046307458"
+	},
+	{
+		"id": "439",
+		"name": "kz_phaztec",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399418936",
+		"mapper_name": "Phinx",
+		"mapper_steamid64": "76561198023207107"
+	},
+	{
+		"id": "440",
+		"name": "kz_pianoclimb_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=230274161",
+		"mapper_name": "DyleT2"
+	},
+	{
+		"id": "441",
+		"name": "kz_pineforest_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=778556068",
+		"mapper_name": "Lillen",
+		"mapper_steamid64": "76561198077858937"
+	},
+	{
+		"id": "442",
+		"name": "kz_piranha",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1185869594",
+		"mapper_name": "GameChaos",
+		"mapper_steamid64": "76561198165203332"
+	},
+	{
+		"id": "443",
+		"name": "kz_pixelrun_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=782827606",
+		"mapper_name": "TheWhaleMan",
+		"mapper_steamid64": "76561198064508818"
+	},
+	{
+		"id": "444",
+		"name": "kz_plains",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=747076334",
+		"mapper_name": "Shire",
+		"mapper_steamid64": "76561198104341799"
+	},
+	{
+		"id": "445",
+		"name": "kz_pollution",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=633854360",
+		"mapper_name": "pr3da",
+		"mapper_steamid64": "76561198021246024"
+	},
+	{
+		"id": "656",
+		"name": "kz_porridge",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1533494110",
+		"mapper_name": "Diesel",
+		"mapper_steamid64": "76561198099241969"
+	},
+	{
+		"id": "806",
+		"name": "kz_portal_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2208043488",
+		"mapper_name": "epic",
+		"mapper_steamid64": "76561198028317188"
+	},
+	{
+		"id": "607",
+		"name": "kz_prekeeper",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1535314044",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "446",
+		"name": "kz_prima",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=896453952",
+		"mapper_name": "Cobrex",
+		"mapper_steamid64": "76561198060634245"
+	},
+	{
+		"id": "447",
+		"name": "kz_prismus",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080437",
+		"mapper_name": "Deepus",
+		"mapper_steamid64": "76561197976153012"
+	},
+	{
+		"id": "946",
+		"name": "kz_procrastination_f",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2370566385",
+		"mapper_name": "lenny",
+		"mapper_steamid64": "76561198145963095"
+	},
+	{
+		"id": "956",
+		"name": "kz_progressive",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2421910892",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "448",
+		"name": "kz_project",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=656536301",
+		"mapper_name": "Isk",
+		"mapper_steamid64": "76561198195095059"
+	},
+	{
+		"id": "782",
+		"name": "kz_prolific",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2091137824",
+		"mapper_name": "jord",
+		"mapper_steamid64": "76561198066952826"
+	},
+	{
+		"id": "608",
+		"name": "kz_prototype",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=520364028",
+		"mapper_name": "Smex",
+		"mapper_steamid64": "76561197961558198"
+	},
+	{
+		"id": "910",
+		"name": "kz_psychosomatic",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2422388657",
+		"mapper_name": "Plastyc, Raunox",
+		"mapper_steamid64": "76561199024218227, 76561198254175551"
+	},
+	{
+		"id": "790",
+		"name": "kz_psyk",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030706198",
+		"mapper_name": "G O A",
+		"mapper_steamid64": "76561197990887735"
+	},
+	{
+		"id": "449",
+		"name": "kz_psytime_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=623887144",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "745",
+		"name": "kz_purgatory",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1943903062",
+		"mapper_name": "Amber, htc, Rebmaa",
+		"mapper_steamid64": "null, null, 76561197970776455 "
+	},
+	{
+		"id": "450",
+		"name": "kz_quadrablock",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068013",
+		"mapper_name": "Pix"
+	},
+	{
+		"id": "451",
+		"name": "kz_quadrant_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1369715256",
+		"mapper_name": "River",
+		"mapper_steamid64": "76561198054436805"
+	},
+	{
+		"id": "452",
+		"name": "kz_quick7_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=562956061",
+		"mapper_name": "MurrayAU",
+		"mapper_steamid64": "76561198019551123"
+	},
+	{
+		"id": "620",
+		"name": "kz_quicksand",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1579335691",
+		"mapper_name": "Sisms(?)",
+		"mapper_steamid64": "76561198166999579"
+	},
+	{
+		"id": "453",
+		"name": "kz_quickshot",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=437195052",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "454",
+		"name": "kz_quixotic",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=581076797",
+		"mapper_name": "Matilda",
+		"mapper_steamid64": "76561197999312081"
+	},
+	{
+		"id": "455",
+		"name": "kz_railings",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=301219724",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "456",
+		"name": "kz_rainrun_kn_f",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=509126081",
+		"mapper_name": "Knove",
+		"mapper_steamid64": "76561198109227174"
+	},
+	{
+		"id": "457",
+		"name": "kz_rcn_impermanence",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1235824121",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "458",
+		"name": "kz_rcn_optimisery",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1228153185",
+		"mapper_name": "archon",
+		"mapper_steamid64": "76561198034601835"
+	},
+	{
+		"id": "459",
+		"name": "kz_reach_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=421596934",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "813",
+		"name": "kz_rectangle",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2127477792",
+		"mapper_name": "Michael",
+		"mapper_steamid64": "76561198004229810"
+	},
+	{
+		"id": "460",
+		"name": "kz_redemption_csgo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=269756340",
+		"mapper_name": "Tipii, fl0w",
+		"mapper_steamid64": "null, 76561197991750093"
+	},
+	{
+		"id": "461",
+		"name": "kz_redline",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=366676291",
+		"mapper_name": "ExtremerZ",
+		"mapper_steamid64": "76561197965479288"
+	},
+	{
+		"id": "764",
+		"name": "kz_refract",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2054929131",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "901",
+		"name": "kz_refuge",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2260756501",
+		"mapper_name": "nykaN",
+		"mapper_steamid64": "76561198014491259"
+	},
+	{
+		"id": "462",
+		"name": "kz_remedy_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=458847658",
+		"mapper_name": "Piu",
+		"mapper_steamid64": "76561198014009703"
+	},
+	{
+		"id": "688",
+		"name": "kz_research",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1233676255",
+		"mapper_name": "Fafnir",
+		"mapper_steamid64": "76561198072210646"
+	},
+	{
+		"id": "463",
+		"name": "kz_retribution_v2_final",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=535037159",
+		"mapper_name": "Flux",
+		"mapper_steamid64": "76561198040691989"
+	},
+	{
+		"id": "464",
+		"name": "kz_return",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=610279618",
+		"mapper_name": "DanZay",
+		"mapper_steamid64": "76561197989817982"
+	},
+	{
+		"id": "899",
+		"name": "kz_reverse",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2261076218",
+		"mapper_name": "Temmie, Da0lang",
+		"mapper_steamid64": "76561198137502865, 76561198814294487"
+	},
+	{
+		"id": "628",
+		"name": "kz_rise",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=661509726",
+		"mapper_name": "schm0ftie",
+		"mapper_steamid64": "76561197983561860"
+	},
+	{
+		"id": "465",
+		"name": "kz_rockclimb",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=294354248",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "466",
+		"name": "kz_rockjungle_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=706798826",
+		"mapper_name": "GWB",
+		"mapper_steamid64": "76561198010817168"
+	},
+	{
+		"id": "467",
+		"name": "kz_rocks_global",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1728344964",
+		"mapper_name": "keyuu",
+		"mapper_steamid64": "76561198003202977"
+	},
+	{
+		"id": "765",
+		"name": "kz_roman",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2071759440",
+		"mapper_name": "Ori",
+		"mapper_steamid64": "76561198157565655"
+	},
+	{
+		"id": "874",
+		"name": "kz_rompenutrias_asheglado",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1528890944",
+		"mapper_name": "Shendal",
+		"mapper_steamid64": "76561198225775664"
+	},
+	{
+		"id": "555",
+		"name": "kz_rumzor",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1157701765",
+		"mapper_name": "Rumme",
+		"mapper_steamid64": "76561198112936613"
+	},
+	{
+		"id": "852",
+		"name": "kz_rush2sk8",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2212481749",
+		"mapper_name": "rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "919",
+		"name": "kz_rush2suck",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2346899830",
+		"mapper_name": "Krushed, stz, nopey",
+		"mapper_steamid64": "76561197966948458, 76561198261992780, 76561198401447544"
+	},
+	{
+		"id": "468",
+		"name": "kz_sanctuary",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387095066",
+		"mapper_name": "Ace"
+	},
+	{
+		"id": "469",
+		"name": "kz_sandstone_mq",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=318255698",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "470",
+		"name": "kz_sandstorm_ez",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=399829430",
+		"mapper_name": "DropInMilk",
+		"mapper_steamid64": "76561198033385282"
+	},
+	{
+		"id": "471",
+		"name": "kz_sandyhill_hoc",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068273",
+		"mapper_name": "SinFuL",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "886",
+		"name": "kz_scum",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2262738254",
+		"mapper_name": "dillon",
+		"mapper_steamid64": "76561198120868833"
+	},
+	{
+		"id": "472",
+		"name": "kz_sendhelp_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=414276208",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "473",
+		"name": "kz_serenity",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=564068433",
+		"mapper_name": "UnderhellCS",
+		"mapper_steamid64": "76561198071769233"
+	},
+	{
+		"id": "877",
+		"name": "kz_shaft_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2228832434",
+		"mapper_name": "Beikenost",
+		"mapper_steamid64": "76561198117002699"
+	},
+	{
+		"id": "671",
+		"name": "kz_shell",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1640657838",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "766",
+		"name": "kz_shortcut_tx",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2059971679",
+		"mapper_name": "Elem",
+		"mapper_steamid64": "76561199023877609"
+	},
+	{
+		"id": "475",
+		"name": "kz_signs_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=570362293",
+		"mapper_name": "Guta",
+		"mapper_steamid64": "76561198000799482"
+	},
+	{
+		"id": "726",
+		"name": "kz_simplejourney",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1842969271",
+		"mapper_name": "ρ",
+		"mapper_steamid64": "76561198002830622"
+	},
+	{
+		"id": "725",
+		"name": "kz_simple_sp",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1995891136",
+		"mapper_name": "saicho91",
+		"mapper_steamid64": "76561197995141366"
+	},
+	{
+		"id": "476",
+		"name": "kz_simplicity_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=596881274",
+		"mapper_name": "Netcode",
+		"mapper_steamid64": "76561198083399596"
+	},
+	{
+		"id": "836",
+		"name": "kz_skybridge",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2170006392",
+		"mapper_name": "Aquilla",
+		"mapper_steamid64": "76561198337861414"
+	},
+	{
+		"id": "477",
+		"name": "kz_skyhotel",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=508852626",
+		"mapper_name": "Flux",
+		"mapper_steamid64": "76561198040691989"
+	},
+	{
+		"id": "556",
+		"name": "kz_sky_lake",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1298788457",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "479",
+		"name": "kz_slate",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=871544753",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "702",
+		"name": "kz_slidebober",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1825259311",
+		"mapper_name": "Slyph"
+	},
+	{
+		"id": "746",
+		"name": "kz_slidemap_ez_v2_rmk_final",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2421819231",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "949",
+		"name": "kz_slide_concrete",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2356803567",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "775",
+		"name": "kz_slide_deee",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2016401059",
+		"mapper_name": "Dima",
+		"mapper_steamid64": "76561198198062889"
+	},
+	{
+		"id": "632",
+		"name": "kz_slide_dydanhomon",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1586833508",
+		"mapper_name": "dydka",
+		"mapper_steamid64": "76561198010747369"
+	},
+	{
+		"id": "797",
+		"name": "kz_slide_kissa",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2081916777",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "757",
+		"name": "kz_slide_koira",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2010190400",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "909",
+		"name": "kz_slide_pallokala",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2288332530",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "890",
+		"name": "kz_slide_pisauva",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2251257791",
+		"mapper_name": "Shendal",
+		"mapper_steamid64": "76561198225775664"
+	},
+	{
+		"id": "703",
+		"name": "kz_slide_purple_x",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1842176999",
+		"mapper_name": "Kirman, PreFect"
+	},
+	{
+		"id": "945",
+		"name": "kz_slide_rawr_xdeee",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2190416060",
+		"mapper_name": "Dima",
+		"mapper_steamid64": "76561198198062889"
+	},
+	{
+		"id": "727",
+		"name": "kz_slide_rovod",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2418190102",
+		"mapper_name": "rov, Overdose",
+		"mapper_steamid64": "76561198132236283, 76561198142809343"
+	},
+	{
+		"id": "609",
+		"name": "kz_slide_svn_extreme",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1545821165",
+		"mapper_name": "SilverNinja"
+	},
+	{
+		"id": "704",
+		"name": "kz_slide_svn_temple",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1866612534",
+		"mapper_name": "SilverNinja"
+	},
+	{
+		"id": "821",
+		"name": "kz_slide_vaahtera",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2184236748",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "818",
+		"name": "kz_slowrun_global_fix",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1355920261",
+		"mapper_name": "cnc3ep1",
+		"mapper_steamid64": "76561198143741877"
+	},
+	{
+		"id": "672",
+		"name": "kz_slumpfrageous",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1741709684",
+		"mapper_name": "victoria248",
+		"mapper_steamid64": "76561198026839022"
+	},
+	{
+		"id": "789",
+		"name": "kz_smallcastle",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2025955407",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "573",
+		"name": "kz_smallmap",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1339159026",
+		"mapper_name": "Samuel",
+		"mapper_steamid64": "76561198191875674"
+	},
+	{
+		"id": "480",
+		"name": "kz_snowman_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=337956674",
+		"mapper_name": "DutchSnowman",
+		"mapper_steamid64": "76561198027507070"
+	},
+	{
+		"id": "481",
+		"name": "kz_solidarity_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580922647",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "955",
+		"name": "kz_sonder",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2385596806",
+		"mapper_name": "dillon",
+		"mapper_steamid64": "76561198120868833"
+	},
+	{
+		"id": "853",
+		"name": "kz_sp1_bloodyljs",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224266412",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "880",
+		"name": "kz_sp1_candles",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2243496277",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "912",
+		"name": "kz_sp1_castaway",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2283294555",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "935",
+		"name": "kz_sp1_hallwaybhop",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2305555371",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "854",
+		"name": "kz_sp1_hiragana",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2210394074",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "948",
+		"name": "kz_sp1_katakana",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2381711985",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "927",
+		"name": "kz_sp1_perf2win",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2322149205",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "861",
+		"name": "kz_spaceladders_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2229077733",
+		"mapper_name": "Cybur",
+		"mapper_steamid64": "76561198062384407"
+	},
+	{
+		"id": "557",
+		"name": "kz_spacemario_h",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685184665",
+		"mapper_name": "Eightb0",
+		"mapper_steamid64": "76561198010762038"
+	},
+	{
+		"id": "482",
+		"name": "kz_spacus",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=522846216",
+		"mapper_name": "Deepus, Hawk",
+		"mapper_steamid64": "76561197976153012, 76561198218057127"
+	},
+	{
+		"id": "846",
+		"name": "kz_spire",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2205432051",
+		"mapper_name": "RZL, Fnugz",
+		"mapper_steamid64": "76561197985774978, 76561198012891563"
+	},
+	{
+		"id": "483",
+		"name": "kz_spiritblockv2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068550",
+		"mapper_name": "jYue, SoUlFaThEr",
+		"mapper_steamid64": "null, 76561197965266419"
+	},
+	{
+		"id": "812",
+		"name": "kz_splopkopsc_loverick",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1126798978",
+		"mapper_name": "Steez",
+		"mapper_steamid64": "76561198261992780"
+	},
+	{
+		"id": "484",
+		"name": "kz_spores_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=418447771",
+		"mapper_name": "G O A",
+		"mapper_steamid64": "76561197990887735"
+	},
+	{
+		"id": "485",
+		"name": "kz_sqrdsucks",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=870091342",
+		"mapper_name": "Krushed",
+		"mapper_steamid64": "76561197966948458"
+	},
+	{
+		"id": "855",
+		"name": "kz_stepblock",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2221286065",
+		"mapper_name": "Crixxzi",
+		"mapper_steamid64": "76561198046307458"
+	},
+	{
+		"id": "954",
+		"name": "kz_stepup",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2378820376",
+		"mapper_name": "Emzatin",
+		"mapper_steamid64": "76561198393292046"
+	},
+	{
+		"id": "486",
+		"name": "kz_strafehop_fix",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=727970399",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "487",
+		"name": "kz_stranded",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=881021394",
+		"mapper_name": "nykaN, coach",
+		"mapper_steamid64": "76561198014491259, 76561197969061501"
+	},
+	{
+		"id": "488",
+		"name": "kz_streetblock_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=340164148",
+		"mapper_name": "s0lid",
+		"mapper_steamid64": "76561197980460370"
+	},
+	{
+		"id": "856",
+		"name": "kz_structures",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=613750240",
+		"mapper_name": "colony",
+		"mapper_steamid64": "76561198012716104"
+	},
+	{
+		"id": "489",
+		"name": "kz_strun_mq",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=522194087",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "490",
+		"name": "kz_stuff_final",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=397542914",
+		"mapper_name": "Pebi",
+		"mapper_steamid64": "76561198077530872"
+	},
+	{
+		"id": "491",
+		"name": "kz_sukblock_v2_fixed",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=511719435",
+		"mapper_name": "Suck' TearZ"
+	},
+	{
+		"id": "492",
+		"name": "kz_summercliff2_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=201718436",
+		"mapper_name": "s0liD",
+		"mapper_steamid64": "76561197980460370"
+	},
+	{
+		"id": "776",
+		"name": "kz_suomi",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030976502",
+		"mapper_name": "tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "915",
+		"name": "kz_superstructure",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2252104070",
+		"mapper_name": "_max",
+		"mapper_steamid64": "76561198083065598"
+	},
+	{
+		"id": "944",
+		"name": "kz_surf_ace",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2366218120",
+		"mapper_name": "Dima, Juxtapo",
+		"mapper_steamid64": "76561198198062889, 76561197982874432"
+	},
+	{
+		"id": "705",
+		"name": "kz_surf_blue",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1777661554",
+		"mapper_name": "CyclO",
+		"mapper_steamid64": "76561198024466262"
+	},
+	{
+		"id": "494",
+		"name": "kz_surf_kim_hana_gl",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=846934364",
+		"mapper_name": "Gull",
+		"mapper_steamid64": "76561198137589262"
+	},
+	{
+		"id": "495",
+		"name": "kz_swamped_v3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=737262158",
+		"mapper_name": "Orbit",
+		"mapper_steamid64": "76561198057269402"
+	},
+	{
+		"id": "496",
+		"name": "kz_symbiosis_final",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=407752167",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "835",
+		"name": "kz_symmetry",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2169425331",
+		"mapper_name": "Lameskydiver",
+		"mapper_steamid64": "76561198082880577"
+	},
+	{
+		"id": "219",
+		"name": "kz_synergy_ez",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030361679",
+		"mapper_name": "pLANE, fl0w",
+		"mapper_steamid64": "76561197969425557, 76561197991750093"
+	},
+	{
+		"id": "220",
+		"name": "kz_synergy_x",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2030360282",
+		"mapper_name": "pLANE, fl0w",
+		"mapper_steamid64": "76561197969425557, 76561197991750093"
+	},
+	{
+		"id": "497",
+		"name": "kz_synthesis_v2",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=524273901",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "498",
+		"name": "kz_sz_goldenbean",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=279111456",
+		"mapper_name": "SinFuL",
+		"mapper_steamid64": "76561197970838363"
+	},
+	{
+		"id": "500",
+		"name": "kz_talltreeforest_v3",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=353767057",
+		"mapper_name": "Vypur",
+		"mapper_steamid64": "76561198027553039"
+	},
+	{
+		"id": "501",
+		"name": "kz_talmaniac",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=875664112",
+		"mapper_name": "AREDONE, GameChaos",
+		"mapper_steamid64": "76561198082306844, 76561198165203332"
+	},
+	{
+		"id": "857",
+		"name": "kz_technical_difficulties",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215677224",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "637",
+		"name": "kz_techtonic_v2_ldr",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1679345238",
+		"mapper_name": "iBUYFL0WER Birgit",
+		"mapper_steamid64": "76561198078014747"
+	},
+	{
+		"id": "502",
+		"name": "kz_terablock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=269563440",
+		"mapper_name": "SinFul, fl0w",
+		"mapper_steamid64": "null, 76561197991750093"
+	},
+	{
+		"id": "816",
+		"name": "kz_theaquila",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2183036742",
+		"mapper_name": "Aquilla",
+		"mapper_steamid64": "76561198337861414"
+	},
+	{
+		"id": "610",
+		"name": "kz_thinkblock",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1543810415",
+		"mapper_name": "xq, GameChaos",
+		"mapper_steamid64": "76561198094382485, 76561198165203332"
+	},
+	{
+		"id": "748",
+		"name": "kz_thrombosis",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1803151428",
+		"mapper_name": "rov",
+		"mapper_steamid64": "76561198132236283"
+	},
+	{
+		"id": "503",
+		"name": "kz_timescape_zero",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=937263331",
+		"mapper_name": "Blixx",
+		"mapper_steamid64": "76561198017413484"
+	},
+	{
+		"id": "504",
+		"name": "kz_tomb_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1099232235",
+		"mapper_name": "MoHaX_cm"
+	},
+	{
+		"id": "505",
+		"name": "kz_toonadventure_go",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156068846",
+		"mapper_name": "PHQ",
+		"mapper_steamid64": "76561197981825703"
+	},
+	{
+		"id": "506",
+		"name": "kz_toonrun_final",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=375234842",
+		"mapper_name": "BigBangQuint"
+	},
+	{
+		"id": "673",
+		"name": "kz_toughluck_fix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1740708159",
+		"mapper_name": "TurboAgent"
+	},
+	{
+		"id": "508",
+		"name": "kz_tour_de_nuke_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406055304",
+		"mapper_name": "bacUp",
+		"mapper_steamid64": "76561197992737822"
+	},
+	{
+		"id": "509",
+		"name": "kz_tradeblock_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=352763435",
+		"mapper_name": "Millet"
+	},
+	{
+		"id": "510",
+		"name": "kz_trashsurf",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419954977",
+		"mapper_name": "ticK!",
+		"mapper_steamid64": "76561198171545305"
+	},
+	{
+		"id": "783",
+		"name": "kz_trazodon_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2167786919",
+		"mapper_name": "Zeldox",
+		"mapper_steamid64": "76561197965379945"
+	},
+	{
+		"id": "511",
+		"name": "kz_tribute",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=771511732",
+		"mapper_name": "darksy",
+		"mapper_steamid64": "76561197985961109"
+	},
+	{
+		"id": "512",
+		"name": "kz_tron_global",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406055395"
+	},
+	{
+		"id": "677",
+		"name": "kz_twiivo",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1755261291",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198094382485"
+	},
+	{
+		"id": "493",
+		"name": "kz_twilight_od",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1885058481",
+		"mapper_name": "Overdose",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "787",
+		"name": "kz_twister",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2104121795",
+		"mapper_name": "Fksch",
+		"mapper_steamid64": "76561198142682783"
+	},
+	{
+		"id": "893",
+		"name": "kz_unity_collab",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=864605202",
+		"mapper_name": "G O A, Magical, ρ",
+		"mapper_steamid64": "76561197990887735, 76561197994466910, 76561198002830622"
+	},
+	{
+		"id": "513",
+		"name": "kz_unity_u01",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=519498299",
+		"mapper_name": "zPrince",
+		"mapper_steamid64": "76561198047032125"
+	},
+	{
+		"id": "690",
+		"name": "kz_unknownspace",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1738660683",
+		"mapper_name": "mjb",
+		"mapper_steamid64": "76561198093921774"
+	},
+	{
+		"id": "865",
+		"name": "kz_unmake",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2201592299",
+		"mapper_name": "Chichin",
+		"mapper_steamid64": "76561197991555455"
+	},
+	{
+		"id": "878",
+		"name": "kz_variety_fix",
+		"difficulty": "4",
+		"workshop_url": " https://steamcommunity.com/sharedfiles/filedetails/?id=2251584934",
+		"mapper_name": "Emzatin",
+		"mapper_steamid64": "76561198393292046"
+	},
+	{
+		"id": "514",
+		"name": "kz_vci_apprentice",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685276922",
+		"mapper_name": "VCi",
+		"mapper_steamid64": "76561198177716323"
+	},
+	{
+		"id": "515",
+		"name": "kz_verv3_gg",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=568150287",
+		"mapper_name": "Greg",
+		"mapper_steamid64": "76561198029772319"
+	},
+	{
+		"id": "630",
+		"name": "kz_village",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1613996676",
+		"mapper_name": "biql, GameChaos",
+		"mapper_steamid64": "76561198146445979, 76561198165203332"
+	},
+	{
+		"id": "516",
+		"name": "kz_violet_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=603787190",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "674",
+		"name": "kz_vittu_mika_persse",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1735347577",
+		"mapper_name": "victoria248",
+		"mapper_steamid64": "76561198026839022"
+	},
+	{
+		"id": "517",
+		"name": "kz_void",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=789833143",
+		"mapper_name": "finckelton",
+		"mapper_steamid64": "76561198039388458"
+	},
+	{
+		"id": "518",
+		"name": "kz_warehouse",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=288587982",
+		"mapper_name": "Witchhowl",
+		"mapper_steamid64": "76561198027343851"
+	},
+	{
+		"id": "657",
+		"name": "kz_waterhole",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1656359071",
+		"mapper_name": "lazovsky"
+	},
+	{
+		"id": "777",
+		"name": "kz_weebfactory_censored",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2110341385",
+		"mapper_name": "mark",
+		"mapper_steamid64": "76561198045869085"
+	},
+	{
+		"id": "611",
+		"name": "kz_wetbricks",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1341015034",
+		"mapper_name": "Random Eye",
+		"mapper_steamid64": "76561197987069371"
+	},
+	{
+		"id": "519",
+		"name": "kz_whatever_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=439146522",
+		"mapper_name": "GemaYue",
+		"mapper_steamid64": "76561198019909186"
+	},
+	{
+		"id": "678",
+		"name": "kz_why",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1773239409",
+		"mapper_name": "archon, Overdose",
+		"mapper_steamid64": "76561198034601835, 76561198142809343"
+	},
+	{
+		"id": "520",
+		"name": "kz_woodstock_v2",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=620160091",
+		"mapper_name": "pr3da",
+		"mapper_steamid64": "76561198021246024"
+	},
+	{
+		"id": "521",
+		"name": "kz_woodstonegrass_final",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=594369922",
+		"mapper_name": "MurrayAU",
+		"mapper_steamid64": "76561198019551123"
+	},
+	{
+		"id": "522",
+		"name": "kz_woodworld",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=306647639",
+		"mapper_name": "masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "523",
+		"name": "kz_xand",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=387908744",
+		"mapper_name": "a$ce"
+	},
+	{
+		"id": "615",
+		"name": "kz_xmas2008",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118382",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "616",
+		"name": "kz_xmas2009",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1627118842",
+		"mapper_name": "FoF, ρ",
+		"mapper_steamid64": "76561197991832101, 76561198002830622"
+	},
+	{
+		"id": "907",
+		"name": "kz_xmas2020",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2224396057",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "524",
+		"name": "kz_xtremeblock_v2",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156069128",
+		"mapper_name": "Chrizzy"
+	},
+	{
+		"id": "574",
+		"name": "kz_yoink",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1308906365",
+		"mapper_name": "bainz, GameChaos",
+		"mapper_steamid64": "76561198183817078, 76561198165203332"
+	},
+	{
+		"id": "822",
+		"name": "kz_zaloopazxc",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1918571009",
+		"mapper_name": "downeel",
+		"mapper_steamid64": "76561198160259346"
+	},
+	{
+		"id": "525",
+		"name": "kz_za_tileblock",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406080925",
+		"mapper_name": "Masque",
+		"mapper_steamid64": "76561197979436335"
+	},
+	{
+		"id": "526",
+		"name": "kz_zhop_freestyle",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=685863435",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "527",
+		"name": "kz_zhop_function3",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=606199162",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "528",
+		"name": "kz_zhop_son_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=580178806",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "529",
+		"name": "kz_ziggurath_final",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=684097443",
+		"mapper_name": "burny",
+		"mapper_steamid64": "76561197989457424"
+	},
+	{
+		"id": "729",
+		"name": "kz_zoomer_fix",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1996270299",
+		"mapper_name": "CoD",
+		"mapper_steamid64": "76561198846255522"
+	},
+	{
+		"id": "530",
+		"name": "kz_zxp_final4",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=632673660",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "645",
+		"name": "kz_zxp_interstellar_v2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1667954510",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "531",
+		"name": "kz_zxp_undia",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=639874816",
+		"mapper_name": "Zprince",
+		"mapper_steamid64": "76561198151858167"
+	},
+	{
+		"id": "612",
+		"name": "skz_bananaysoda_2",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1200744110",
+		"mapper_name": "Jony",
+		"mapper_steamid64": "76561198000829729"
+	},
+	{
+		"id": "589",
+		"name": "skz_makalaka",
+		"difficulty": "7",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1340859713",
+		"mapper_name": "Gamechaos",
+		"mapper_steamid64": "76561198165203332"
+	},
+	{
+		"id": "869",
+		"name": "skz_map",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2257677246",
+		"mapper_name": "Rush2sk8",
+		"mapper_steamid64": "76561198082904691"
+	},
+	{
+		"id": "640",
+		"name": "skz_odious_v2",
+		"difficulty": "6",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2001125206",
+		"mapper_name": "xq, Danvari",
+		"mapper_steamid64": "76561198094382485, 76561198038388449"
+	},
+	{
+		"id": "558",
+		"name": "skz_sati",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1226660943",
+		"mapper_name": "xq",
+		"mapper_steamid64": "76561198142809343"
+	},
+	{
+		"id": "891",
+		"name": "skz_sequence_shot",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2263251231",
+		"mapper_name": "lenny",
+		"mapper_steamid64": "76561198145963095"
+	},
+	{
+		"id": "633",
+		"name": "vnl_cat",
+		"difficulty": "4",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1594689613",
+		"mapper_name": "Schrødna",
+		"mapper_steamid64": "76561198067192262"
+	},
+	{
+		"id": "837",
+		"name": "vnl_invasion",
+		"difficulty": "5",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2027995295",
+		"mapper_name": "Birgit",
+		"mapper_steamid64": "76561198078014747"
+	},
+	{
+		"id": "841",
+		"name": "vnl_whiterun",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2209883717",
+		"mapper_name": "Spider1",
+		"mapper_steamid64": "76561198042146961"
+	},
+	{
+		"id": "778",
+		"name": "xc_alt_nephilim",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2072370967",
+		"mapper_name": "G O A",
+		"mapper_steamid64": "76561197990887735"
+	},
+	{
+		"id": "858",
+		"name": "xc_cliffjump_fix",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2215515724",
+		"mapper_name": "Tatska",
+		"mapper_steamid64": "76561198433558585"
+	},
+	{
+		"id": "596",
+		"name": "xc_dreamland2",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1287723058",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "559",
+		"name": "xc_dtt_nasty_go",
+		"difficulty": "1",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1257230741",
+		"mapper_name": "Dogers, ρ",
+		"mapper_steamid64": "null, 76561198002830622"
+	},
+	{
+		"id": "560",
+		"name": "xc_fox_shrine_japan_fr",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1279693156",
+		"mapper_name": "incAming"
+	},
+	{
+		"id": "532",
+		"name": "xc_karo4",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1193986481",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "533",
+		"name": "xc_lucid_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406056737",
+		"mapper_name": "G O A",
+		"mapper_steamid64": "76561197990887735"
+	},
+	{
+		"id": "534",
+		"name": "xc_minecraft2_global",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419053494",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "535",
+		"name": "xc_minecraft3_global",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=406057063",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "758",
+		"name": "xc_minecraft4",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=2025541839",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	},
+	{
+		"id": "536",
+		"name": "xc_nephilim",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=320752458",
+		"mapper_name": "G O A",
+		"mapper_steamid64": "76561197990887735"
+	},
+	{
+		"id": "537",
+		"name": "xc_powerblock_rc1",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=156206701",
+		"mapper_name": "RZL",
+		"mapper_steamid64": "76561197985774978"
+	},
+	{
+		"id": "538",
+		"name": "xc_secret_valley_global_fix",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=451014834",
+		"mapper_name": "Sodan Tok"
+	},
+	{
+		"id": "539",
+		"name": "xc_skycastle",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1660023848",
+		"mapper_name": "Bendix, victoria248",
+		"mapper_steamid64": "null, 76561198026839022"
+	},
+	{
+		"id": "540",
+		"name": "xc_supermario_go_gfix",
+		"difficulty": "2",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=1939578036",
+		"mapper_name": "Disturbed, Iconic"
+	},
+	{
+		"id": "541",
+		"name": "xc_umbrella_global",
+		"difficulty": "3",
+		"workshop_url": "https://steamcommunity.com/sharedfiles/filedetails/?id=419054050",
+		"mapper_name": "ProAqua",
+		"mapper_steamid64": "76561198051496034"
+	}
 ]


### PR DESCRIPTION
Here are some things that I wasn't very sure about:
Likely Tipii cos he's in the kreedz climbing group: 76561197960292250
Likely jYue cos he's in the kreedz climbing group: 76561197966976272

Very likely BigBangQuint, but the profile is private: 76561197963005466

I don't think this is actually Kreedz's steam profile xd: 76561197997103423

Sprite's and Timmycakes's steam IDs are on xj: https://xtreme-jumps.eu/mappers.php
sn00p's profile is also linked, but it's super weird, mistyped maybe? Also the reason why sn00p is on exps is because he made dahnajourney which is in exps. There are more 1.6 maps in there but I don't remember the other ones.

Very likely Bendix: 76561197972289413

Also here are all the mappers on kz_communityjump3, there's a lot so I didn't include them all in the file and only kept the main guys:
Aimerr, Altic, Aux, Avetixz, awful, Azaza, bhop_alex, BLEND, casool, Dign, Eiri, Fabio, FunuSage, Highquality, Hoover, JON3S, Juxtapo, keyuu, mellowed, Nallieheai, Nishi, Pcpie, Prolix, Pytch, sexy_but_not_trying, Shell, Struppi, Tony Montana, Torouxi, tuxxi, tyna, Tyrni, vay, YUKA